### PR TITLE
Renaming gulp build-library target to build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('transpile-less', function () {
 });
 
 // Put the files back to normal
-gulp.task('build-library',
+gulp.task('build',
   [
     'transpile',
     'post-transpile',
@@ -84,11 +84,11 @@ gulp.task('copy-watch', ['post-transpile'], function() {
   return updateWatchDist();
 });
 
-gulp.task('copy-watch-all', ['build-library'], function() {
+gulp.task('copy-watch-all', ['build'], function() {
   return updateWatchDist();
 });
 
-gulp.task('watch', ['build-library', 'copy-watch-all'], function () {
+gulp.task('watch', ['build', 'copy-watch-all'], function () {
   gulp.watch([appSrc + '/app/**/*.ts', '!' + appSrc + '/app/**/*.spec.ts'], ['transpile', 'post-transpile', 'copy-watch']).on('change', function (e) {
     console.log('TypeScript file ' + e.path + ' has been changed. Compiling.');
   });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "npm-run-all --serial remove-dist build:library",
-    "build:library": "gulp build-library",
+    "build:library": "gulp build",
     "bundle": "webpack --config config/webpack.prod.js --progress --profile --bail",
     "clean": "npm cache clean && npm run rimraf -- node_modules doc coverage dist distwatch bundles",
     "cleanup": "rimraf dist/package.json dist/bundles dist/src dist/index.d.ts dist/index.metadata.json dist/index.js dist/index.js.map dist/LICENSE dist/README.md",


### PR DESCRIPTION
Scripts from patternfly-eng-release expect a build target.