### PR TITLE
Rename alm-sort to pfng-sort.

### DIFF
--- a/src/app/sort/examples/sort-example.component.html
+++ b/src/app/sort/examples/sort-example.component.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-sm-12">
       <div class="form-group">
-        <alm-sort [config]="sortConfig" (onChange)="sortChange($event)"></alm-sort>
+        <pfng-sort [config]="sortConfig" (onChange)="sortChange($event)"></pfng-sort>
       </div>
     </div>
   </div>

--- a/src/app/sort/examples/sort-example.component.ts
+++ b/src/app/sort/examples/sort-example.component.ts
@@ -77,11 +77,6 @@ export class SortExampleComponent implements OnInit {
           sortType: 'alpha'
         },
         {
-          id: 'age',
-          title:  'Age',
-          sortType: 'numeric'
-        },
-        {
           id: 'address',
           title:  'Address',
           sortType: 'alpha'
@@ -102,8 +97,6 @@ export class SortExampleComponent implements OnInit {
     let compValue = 0;
     if (this.currentSortField.id === 'name') {
       compValue = item1.name.localeCompare(item2.name);
-    } else if (this.currentSortField.id === 'age') {
-      compValue = item1.age - item2.age;
     } else if (this.currentSortField.id === 'address') {
       compValue = item1.address.localeCompare(item2.address);
     } else if (this.currentSortField.id === 'birthMonth') {

--- a/src/app/sort/sort.component.ts
+++ b/src/app/sort/sort.component.ts
@@ -15,7 +15,7 @@ import { SortEvent } from './sort-event';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  selector: 'alm-sort',
+  selector: 'pfng-sort',
   styleUrls: ['./sort.component.less'],
   templateUrl: './sort.component.html'
 })


### PR DESCRIPTION
Rename alm-sort to pfng-sort and remove obsolete ‘age’ sort example.