### PR TITLE
Added toolbar component

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,3 +39,8 @@ export { SortConfig } from './src/app/sort/sort-config';
 export { SortEvent } from './src/app/sort/sort-event';
 export { SortField } from './src/app/sort/sort-field';
 export { SortModule } from './src/app/sort/sort.module';
+
+// Toolbar
+export { ToolbarConfig } from './src/app/toolbar/toolbar-config';
+export { ToolbarComponent } from './src/app/toolbar/toolbar.component';
+export { ToolbarModule } from './src/app/toolbar/toolbar.module';

--- a/src/app/filters/examples/filter-example.component.html
+++ b/src/app/filters/examples/filter-example.component.html
@@ -1,7 +1,7 @@
 <div class="padding-15">
   <div class="row padding-bottom-15">
     <div class="col-xs-12">
-      <h4>Sample Component Example</h4>
+      <h4>Filter Component Example</h4>
       <hr/>
     </div>
   </div>

--- a/src/app/models/action.ts
+++ b/src/app/models/action.ts
@@ -11,10 +11,10 @@
  * visible - Set to false if this menu option should be hidden
  */
 export class Action {
-  disabled?: boolean = false;
+  disabled?: boolean;
   id?: string;
   name: string;
-  separator?: boolean = false;
+  separator?: boolean;
   template?: string;
   type?: string;
   title?: string;

--- a/src/app/models/view.ts
+++ b/src/app/models/view.ts
@@ -7,7 +7,7 @@
  * title - Optional title, uses as a tooltip for the view selector
  */
 export class View {
-  disabled?: boolean = false;
+  disabled?: boolean;
   iconClass: string;
   id: string;
   title: string;

--- a/src/app/pipes/examples/search-highlight-example.component.html
+++ b/src/app/pipes/examples/search-highlight-example.component.html
@@ -2,7 +2,7 @@
 <div class="padding-15">
   <div class="row padding-bottom-15">
     <div class="col-xs-12">
-      <h4>Sample Component Example</h4>
+      <h4>Search Highlight Pipe Example</h4>
       <hr/>
     </div>
   </div>

--- a/src/app/sort/examples/sort-example.component.html
+++ b/src/app/sort/examples/sort-example.component.html
@@ -1,7 +1,7 @@
 <div class="padding-15">
   <div class="row padding-bottom-15">
     <div class="col-xs-12">
-      <h4>Sample Component Example</h4>
+      <h4>Sort Component Example</h4>
       <hr/>
     </div>
   </div>

--- a/src/app/sort/examples/sort-example.component.ts
+++ b/src/app/sort/examples/sort-example.component.ts
@@ -67,10 +67,6 @@ export class SortExampleComponent implements OnInit {
         title:  'Name',
         sortType: 'alpha'
       }, {
-        id: 'age',
-        title:  'Age',
-        sortType: 'numeric'
-      }, {
         id: 'address',
         title:  'Address',
         sortType: 'alpha'

--- a/src/app/sort/sort-config.ts
+++ b/src/app/sort/sort-config.ts
@@ -8,7 +8,7 @@ import { SortField } from './sort-field';
  * show - Optional flag to show sort functionality
  */
 export class SortConfig {
-  isAscending?: boolean = true;
+  isAscending?: boolean;
   fields: SortField[];
-  show?: boolean = true;
+  show?: boolean;
 }

--- a/src/app/sort/sort.component.ts
+++ b/src/app/sort/sort.component.ts
@@ -26,6 +26,10 @@ export class SortComponent implements OnInit {
 
   show: boolean = false;
   currentField: SortField;
+  defaultConfig: SortConfig = {
+    isAscending: true,
+    show: true
+  } as SortConfig;
   prevConfig: SortConfig;
 
   constructor() {
@@ -43,10 +47,11 @@ export class SortComponent implements OnInit {
   }
 
   setupConfig(): void {
-    if (this.config === undefined) {
-      this.config = {} as SortConfig;
+    if (this.config !== undefined) {
+      _.defaults(this.config, this.defaultConfig);
+    } else {
+      this.config = _.cloneDeep(this.defaultConfig);
     }
-    this.prevConfig = _.cloneDeep(this.config);
 
     if (this.config && this.config.fields && this.config.fields.length > 0) {
       if (this.currentField === undefined) {

--- a/src/app/toolbar/examples/toolbar-example.component.html
+++ b/src/app/toolbar/examples/toolbar-example.component.html
@@ -1,0 +1,110 @@
+<div class="padding-15">
+  <div class="row padding-bottom-15">
+    <div class="col-xs-12">
+      <h4>Toolbar Component Example</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <pfng-toolbar [config]="toolbarConfig"
+                      [actionsTemplate]="actionsTemplate"
+                      (onActionSelect)="handleAction($event)"
+                      (onFilterChange)="filterChanged($event)"
+                      (onFilterFieldSelect)="filterFieldSelected()"
+                      (onFilterTypeAhead)="filterQueries($event)"
+                      (onSortChange)="sortChanged($event)"
+                      (onViewSelect)="viewSelected($event)">
+          <ng-template #actions>
+            <span class="dropdown primary-action" dropdown>
+              <button class="btn btn-default dropdown-toggle" type="button" dropdownToggle>
+               Menu Action<span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu" *dropdownMenu>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" (click)="optionSelected(1)">Option 1</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(2)">Option 2</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(3)">Option 3</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(4)">Option 4</a>
+                </li>
+              </ul>
+            </span>
+            <button class="btn btn-default primary-action" type="button" (click)="doAdd()">
+              <span class="fa fa-plus"></span>
+              Add Action
+            </button>
+          </ng-template>
+        </pfng-toolbar>
+      </div>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Valid Items:</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div *ngFor="let item of items" class="col-md-12">
+        <div class="row">
+          <div class="col-md-3">
+            <span>{{item.name}}</span>
+          </div>
+          <div class="col-md-5">
+            <span>{{item.address}}</span>
+          </div>
+          <div class="col-md-2">
+            <span>{{item.birthMonth}}</span>
+          </div>
+          <div class="col-md-2">
+            <span>{{item.weekDay}}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row" *ngIf="view.id !== 'tableView'">
+    <div class="col-md-12">
+      <label class="events-label">Current Filters: </label>
+    </div>
+  </div>
+  <div class="row" *ngIf="view.id !== 'tableView'">
+    <div class="col-md-12">
+      <textarea rows="5" class="col-md-12">{{filtersText}}</textarea>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <label class="actions-label">Actions: </label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset style="border: 1px black;">
+      <tab heading="html">
+        <include-content src="/src/app/toolbar/examples/toolbar-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="/src/app/toolbar/examples/toolbar-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/toolbar/examples/toolbar-example.component.ts
+++ b/src/app/toolbar/examples/toolbar-example.component.ts
@@ -1,0 +1,416 @@
+import {
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Router } from '@angular/router';
+
+import { Action } from '../../models/action';
+import { ActionsConfig } from '../../models/actions-config';
+import { Filter } from '../../filters/filter';
+import { FilterConfig } from '../../filters/filter-config';
+import { FilterField } from '../../filters/filter-field';
+import { FilterEvent } from '../../filters/filter-event';
+import { SortConfig } from '../../sort/sort-config';
+import { SortField } from '../../sort/sort-field';
+import { SortEvent } from '../../sort/sort-event';
+import { ToolbarConfig } from '../toolbar-config';
+import { View } from '../../models/view';
+import { ViewsConfig } from '../../models/views-config';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'toolbar-example',
+  templateUrl: './toolbar-example.component.html'
+})
+export class ToolbarExampleComponent implements OnInit {
+  @ViewChild('actions') actionsTemplate: TemplateRef<any>;
+
+  actionsConfig: ActionsConfig;
+  actionsText: string = '';
+  allItems: any[];
+  filterConfig: FilterConfig;
+  filtersText: string = '';
+  items: any[];
+  isAscendingSort: boolean = true;
+  separator: Object;
+  sortConfig: SortConfig;
+  currentSortField: SortField;
+  toolbarConfig: ToolbarConfig;
+  viewsConfig: ViewsConfig;
+  view: View;
+  weekDayQueries: any[];
+
+  monthVals: any = {
+    'January': 1,
+    'February': 2,
+    'March': 3,
+    'April': 4,
+    'May': 5,
+    'June': 6,
+    'July': 7,
+    'August': 8,
+    'September': 9,
+    'October': 10,
+    'November': 11,
+    'December': 12
+  };
+
+  weekDayVals: any = {
+    'Sunday': 1,
+    'Monday': 2,
+    'Tuesday': 3,
+    'Wednesday': 4,
+    'Thursday': 5,
+    'Friday': 6,
+    'Saturday': 7
+  };
+
+  constructor(private router: Router) {
+  }
+
+  ngOnInit(): void {
+    this.allItems = [{
+      name: 'Fred Flintstone',
+      address: '20 Dinosaur Way, Bedrock, Washingstone',
+      birthMonth: 'February',
+      birthMonthId: 'month2',
+      weekDay: 'Sunday',
+      weekdayId: 'day1'
+    }, {
+      name: 'John Smith', address: '415 East Main Street, Norfolk, Virginia',
+      birthMonth: 'October',
+      birthMonthId: '10',
+      weekDay: 'Monday',
+      weekdayId: 'day2'
+    }, {
+      name: 'Frank Livingston',
+      address: '234 Elm Street, Pittsburgh, Pennsylvania',
+      birthMonth: 'March',
+      birthMonthId: 'month3',
+      weekDay: 'Tuesday',
+      weekdayId: 'day3'
+    }, {
+      name: 'Judy Green',
+      address: '2 Apple Boulevard, Cincinatti, Ohio',
+      birthMonth: 'December',
+      birthMonthId: 'month12',
+      weekDay: 'Wednesday',
+      weekdayId: 'day4'
+    }, {
+      name: 'Pat Thomas',
+      address: '50 Second Street, New York, New York',
+      birthMonth: 'February',
+      birthMonthId: 'month2',
+      weekDay: 'Thursday',
+      weekdayId: 'day5'
+    }];
+    this.items = this.allItems;
+
+    this.weekDayQueries = [{
+      id: 'day1',
+      value: 'Sunday'
+    }, {
+      id: 'day2',
+      value: 'Monday'
+    }, {
+      id: 'day3',
+      value: 'Tuesday'
+    }, {
+      id: 'day4',
+      value: 'Wednesday'
+    }, {
+      id: 'day5',
+      value: 'Thursday'
+    }, {
+      id: 'day6',
+      value: 'Friday'
+    }, {
+      id: 'day7',
+      value: 'Saturday'
+    }];
+
+    this.filterConfig = {
+      fields: [{
+        id: 'name',
+        title:  'Name',
+        placeholder: 'Filter by Name...',
+        type: 'text'
+      }, {
+        id: 'address',
+        title:  'Address',
+        placeholder: 'Filter by Address...',
+        type: 'text'
+      }, {
+        id: 'birthMonth',
+        title:  'Birth Month',
+        placeholder: 'Filter by Birth Month...',
+        type: 'select',
+        queries: [{
+          id: 'month1',
+          value: 'January'
+        }, {
+          id: 'month2',
+          value: 'February'
+        }, {
+          id: 'month3',
+          value: 'March'
+        }, {
+          id: 'month4',
+          value: 'April'
+        }, {
+          id: 'month5',
+          value: 'May'
+        }, {
+          id: 'month6',
+          value: 'June'
+        }, {
+          id: 'month7',
+          value: 'July'
+        }, {
+          id: 'month8',
+          value: 'August'
+        }, {
+          id: 'month9',
+          value: 'September'
+        }, {
+          id: 'month10',
+          value: 'October'
+        }, {
+          id: 'month11',
+          value: 'November'
+        }, {
+          id: 'month12',
+          value: 'December'
+        }]
+      }, {
+        id: 'weekDay',
+        title: 'Week Day',
+        placeholder: 'Filter by Week Day...',
+        type: 'typeahead',
+        queries: [
+          ...this.weekDayQueries
+        ]
+      }] as FilterField[],
+      resultsCount: this.items.length,
+      appliedFilters: []
+    } as FilterConfig;
+
+    this.sortConfig = {
+      fields: [{
+        id: 'name',
+        title:  'Name',
+        sortType: 'alpha'
+      }, {
+        id: 'address',
+        title:  'Address',
+        sortType: 'alpha'
+      }, {
+        id: 'birthMonth',
+        title:  'Birth Month',
+        sortType: 'alpha'
+      }, {
+        id: 'weekDay',
+        title:  'Week Day',
+        sortType: 'alpha'
+      }],
+      isAscending: this.isAscendingSort
+    } as SortConfig;
+
+    this.actionsConfig = {
+      primaryActions: [{
+        id: 'action1',
+        name: 'Action 1',
+        title: 'Do the first thing'
+      }, {
+        id: 'action2',
+        name: 'Action 2',
+        title: 'Do something else'
+      }],
+      moreActions: [{
+        id: 'moreActions1',
+        name: 'Action',
+        title: 'Perform an action'
+      }, {
+        id: 'moreActions2',
+        name: 'Another Action',
+        title: 'Do something else'
+      }, {
+        disabled: true,
+        id: 'moreActions3',
+        name: 'Disabled Action',
+        title: 'Unavailable action',
+      }, {
+        id: 'moreActions4',
+        name: 'Something Else',
+        title: ''
+      }, {
+        id: 'moreActions5',
+        name: '',
+        separator: true
+      }, {
+        id: 'moreActions6',
+        name: 'Grouped Action 1',
+        title: 'Do something'
+      }, {
+        id: 'moreActions7',
+        name: 'Grouped Action 2',
+        title: 'Do something similar'
+      }]
+    } as ActionsConfig;
+
+    this.viewsConfig = {
+      views: [{
+        id: 'listView',
+        title: 'List View',
+        iconClass: 'fa fa-th-list'
+      }, {
+        id: 'tableView',
+        title: 'Table View',
+        iconClass: 'fa fa-table'
+      }],
+    } as ViewsConfig;
+
+    this.viewsConfig.currentView = this.viewsConfig.views[0];
+    this.view = this.viewsConfig.currentView;
+
+    this.toolbarConfig = {
+      actionsConfig: this.actionsConfig,
+      filterConfig: this.filterConfig,
+      sortConfig: this.sortConfig,
+      viewsConfig: this.viewsConfig
+    } as ToolbarConfig;
+  }
+
+  // Action functions
+
+  doAdd(): void {
+    this.actionsText = 'Add Action\n' + this.actionsText;
+  }
+
+  handleAction(action: Action): void {
+    this.actionsText = action.name + '\n' + this.actionsText;
+    let test = '';
+  }
+
+  optionSelected(option: number): void {
+    this.actionsText = 'Option ' + option + ' selected\n' + this.actionsText;
+  }
+
+  // Filter functions
+
+  applyFilters(filters: Filter[]): void {
+    this.items = [];
+    if (filters && filters.length > 0) {
+      this.allItems.forEach((item) => {
+        if (this.matchesFilters(item, filters)) {
+          this.items.push(item);
+        }
+      });
+    } else {
+      this.items = this.allItems;
+    }
+    this.toolbarConfig.filterConfig.resultsCount = this.items.length;
+  }
+
+  // Handle filter changes
+  filterChanged($event: FilterEvent): void {
+    this.filtersText = '';
+    $event.appliedFilters.forEach((filter) => {
+      this.filtersText += filter.field.title + ' : ' + filter.value + '\n';
+    });
+    this.applyFilters($event.appliedFilters);
+    this.filterFieldSelected($event);
+  }
+
+  // Reset filtered queries
+  filterFieldSelected($event: FilterEvent): void {
+    this.filterConfig.fields.forEach((field) => {
+      if (field.id === 'weekDay') {
+        field.queries = [
+          ...this.weekDayQueries
+        ];
+      }
+    });
+  }
+
+  matchesFilter(item: any, filter: Filter): boolean {
+    let match = true;
+    if (filter.field.id === 'name') {
+      match = item.name.match(filter.value) !== null;
+    } else if (filter.field.id === 'address') {
+      match = item.address.match(filter.value) !== null;
+    } else if (filter.field.id === 'birthMonth') {
+      match = item.birthMonth === filter.value;
+    } else if (filter.field.id === 'weekDay') {
+      match = item.weekDay === filter.value;
+    }
+    return match;
+  }
+
+  matchesFilters(item: any, filters: Filter[]): boolean {
+    let matches = true;
+    filters.forEach((filter) => {
+      if (!this.matchesFilter(item, filter)) {
+        matches = false;
+        return matches;
+      }
+    });
+    return matches;
+  }
+
+  // Filter queries for type ahead
+  filterQueries($event: FilterEvent) {
+    const index = this.filterConfig.fields.findIndex(i => i.id === $event.field.id);
+    let val = $event.value.trim();
+
+    if (this.filterConfig.fields[index].id === 'weekDay') {
+      this.filterConfig.fields[index].queries = [
+        ...this.weekDayQueries.filter((item: any) => {
+          if (item.value) {
+            return (item.value.toLowerCase().indexOf(val.toLowerCase()) > -1);
+          } else {
+            return true;
+          }
+        })
+      ];
+    }
+  }
+
+  // Sort functions
+
+  compare(item1: any, item2: any): number {
+    let compValue = 0;
+    if (this.currentSortField.id === 'name') {
+      compValue = item1.name.localeCompare(item2.name);
+    } else if (this.currentSortField.id === 'address') {
+      compValue = item1.address.localeCompare(item2.address);
+    } else if (this.currentSortField.id === 'birthMonth') {
+      compValue = this.monthVals[item1.birthMonth] - this.monthVals[item2.birthMonth];
+    } else if (this.currentSortField.id === 'weekDay') {
+      compValue = this.weekDayVals[item1.weekDay] - this.weekDayVals[item2.weekDay];
+    }
+
+    if (!this.isAscendingSort) {
+      compValue = compValue * -1;
+    }
+    return compValue;
+  }
+
+  // Handle sort changes
+  sortChanged($event: SortEvent): void {
+    this.currentSortField = $event.field;
+    this.isAscendingSort = $event.isAscending;
+    this.items.sort((item1: any, item2: any) => this.compare(item1, item2));
+  }
+
+  // View functions
+
+  viewSelected(view: View): void {
+    this.view = view;
+    this.sortConfig.show = (this.view.id === 'tableView' ? false : true);
+  }
+}

--- a/src/app/toolbar/examples/toolbar-example.module.ts
+++ b/src/app/toolbar/examples/toolbar-example.module.ts
@@ -1,0 +1,26 @@
+import { NgModule }  from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
+
+import { DemoComponentsModule } from '../../../demo/components/demo-components.module';
+import { FiltersModule } from '../../filters/filters.module';
+import { ToolbarModule } from '../toolbar.module';
+import { ToolbarExampleComponent } from './toolbar-example.component';
+
+@NgModule({
+  declarations: [ ToolbarExampleComponent ],
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    DemoComponentsModule,
+    FiltersModule,
+    TabsModule.forRoot(),
+    ToolbarModule
+  ],
+  providers: [ BsDropdownConfig, TabsetConfig ]
+})
+export class ToolbarExampleModule {
+  constructor() {}
+}

--- a/src/app/toolbar/toolbar-config.ts
+++ b/src/app/toolbar/toolbar-config.ts
@@ -1,0 +1,19 @@
+import { ActionsConfig } from '../models/actions-config';
+import { FilterConfig } from '../filters/filter-config';
+import { SortConfig } from '../sort/sort-config';
+import { ViewsConfig } from '../models/views-config';
+
+/*
+ * A toolbar config containing:
+ *
+ * actionsConfig - Optional configuration settings for toolbar actions
+ * filterConfig - Optional filter config. If undefined, no filtering capabilities are shown.
+ * sortConfig  - Optional sort config. If undefined, no sort capabilities are shown.
+ * viewsConfig - Optional configuration settings for view type selection
+ */
+export class ToolbarConfig {
+  actionsConfig?: ActionsConfig;
+  filterConfig?: FilterConfig;
+  sortConfig?: SortConfig;
+  viewsConfig?: ViewsConfig;
+}

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -1,0 +1,62 @@
+<div class="row toolbar-pf">
+  <div class="col-sm-12">
+    <form class="toolbar-pf-actions" [ngClass]="{'no-filter-results': !filterFields}" (submit)="submit($event)">
+      <div class="form-group toolbar-apf-filter">
+        <pfng-filter-fields [config]="config.filterConfig" *ngIf="config.filterConfig?.fields"
+                            (onAdd)="filterAdded($event)"
+                            (onFieldSelect)="handleFilterFieldSelect($event)"
+                            (onTypeAhead)="handleFilterTypeAhead($event)"></pfng-filter-fields>
+      </div>
+      <div class="form-group" *ngIf="config.sortConfig?.fields && config.sortConfig?.show">
+        <pfng-sort [config]="config.sortConfig" (onChange)="sortChange($event)"></pfng-sort>
+      </div>
+      <div class="form-group toolbar-actions"
+           *ngIf="config.actionsConfig !== undefined || actionsTemplate !== undefined">
+        <span *ngIf="config.actionsConfig?.primaryActions?.length > 0">
+          <button class="btn btn-default primary-action" type="button"
+                  *ngFor="let action of config.actionsConfig?.primaryActions"
+                  title="{{action.title}}"
+                  (click)="handleAction(action)"
+                  [disabled]="action.disabled === true">
+            {{action.name}}
+          </button>
+        </span>
+        <div class="toolbar-pf-include-actions">
+          <ng-template [ngTemplateOutlet]="actionsTemplate" [ngOutletContext]="{}"></ng-template>
+        </div>
+        <div class="dropdown dropdown-kebab-pf" dropdown
+             *ngIf="config.actionsConfig?.moreActions.length > 0">
+          <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
+            <span class="fa fa-ellipsis-v"></span>
+          </button>
+          <ul class="dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
+            <li *ngFor="let action of config.actionsConfig?.moreActions"
+                [attr.role]="action.separator === true ? 'separator' : 'menuitem'"
+                [ngClass]="{'divider': action.separator === true, 'disabled': action.disabled === true}">
+              <a *ngIf="action.separator !== true"
+                 class="dropdown-item secondary-action"
+                 title="{{action.title}}"
+                 (click)="handleAction(action)">
+                {{action.name}}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="toolbar-pf-action-right">
+        <div class="form-group toolbar-pf-view-selector"
+             *ngIf="viewsTemplate !== undefined || (config.viewsConfig?.views)">
+          <ng-template [ngTemplateOutlet]="viewsTemplate" [ngOutletContext]="{}"></ng-template>
+          <span *ngIf="config.viewsConfig">
+            <button *ngFor="let view of config.viewsConfig?.views" class="btn btn-link"
+                    [ngClass]="{'active': isViewSelected(view), 'disabled': view.disabled === true}"
+                    title={{view.title}}  (click)="viewSelected(view)">
+              <i class="{{view.iconClass}}"></i>
+            </button>
+          </span>
+        </div>
+      </div>
+    </form>
+    <pfng-filter-results [config]="config.filterConfig" (onClear)="clearFilter($event)"></pfng-filter-results>
+  </div>
+</div>

--- a/src/app/toolbar/toolbar.component.less
+++ b/src/app/toolbar/toolbar.component.less
@@ -1,0 +1,30 @@
+@import (reference) "../../assets/stylesheets/patternfly-ng";
+
+.dropdown-kebab-pf.invisible {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toolbar-pf-actions {
+  .btn { min-width: unset; }
+  .toolbar-pf-view-selector {
+    a { cursor: pointer; }
+  }
+  .dropdown-menu {
+    a { cursor: pointer; }
+  }
+  .dropdown-kebab-pf { float: right; }
+  .toolbar-apf-filter {
+    padding-left: 0 !important;
+    @media (min-width: 768px) {
+      padding-left: 0;
+    }
+  }
+}
+
+.toolbar-pf-include-actions {
+  display: inline-block;
+  margin: 0 5px;
+}
+
+.toolbar-pf-actions.no-filter-results { margin-bottom: 10px; }

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,591 @@
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+
+import { Action } from '../models/action';
+import { ActionsConfig } from '../models/actions-config';
+import { Filter } from '../filters/filter';
+import { FilterConfig } from '../filters/filter-config';
+import { FilterField } from '../filters/filter-field';
+import { FilterFieldsComponent } from '../filters/filter-fields.component';
+import { FilterResultsComponent } from '../filters/filter-results.component';
+import { SearchHighlightModule } from './../pipes/search-highlight.module';
+import { SortComponent } from '../sort/sort.component';
+import { SortConfig } from '../sort/sort-config';
+import { SortEvent } from '../sort/sort-event';
+import { ToolbarComponent } from './toolbar.component';
+import { ToolbarConfig } from './toolbar-config';
+import { View } from '../models/view';
+import { ViewsConfig } from '../models/views-config';
+
+describe('Toolbar component - ', () => {
+  let comp: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+  let config: ToolbarConfig;
+
+  beforeEach(() => {
+    config = {
+      actionsConfig: {
+        primaryActions: [{
+          id: 'action1',
+          name: 'Action 1',
+          title: 'Do the first thing'
+        }, {
+          id: 'action2',
+          name: 'Action 2',
+          title: 'Do something else'
+        }],
+        moreActions: [{
+          id: 'moreActions1',
+          name: 'Action',
+          title: 'Perform an action'
+        }, {
+          id: 'moreActions2',
+          name: 'Another Action',
+          title: 'Do something else'
+        }, {
+          disabled: true,
+          id: 'moreActions3',
+          name: 'Disabled Action',
+          title: 'Unavailable action',
+        }, {
+          id: 'moreActions4',
+          name: 'Something Else',
+          title: ''
+        }, {
+          id: 'moreActions5',
+          name: '',
+          separator: true
+        }, {
+          id: 'moreActions6',
+          name: 'Grouped Action 1',
+          title: 'Do something'
+        }, {
+          id: 'moreActions7',
+          name: 'Grouped Action 2',
+          title: 'Do something similar'
+        }]
+      } as ActionsConfig,
+
+      filterConfig: {
+        fields: [{
+          id: 'name',
+          title:  'Name',
+          placeholder: 'Filter by Name...',
+          type: 'text'
+        }, {
+          id: 'age',
+          title:  'Age',
+          placeholder: 'Filter by Age...',
+          type: 'text'
+        }, {
+          id: 'address',
+          title:  'Address',
+          placeholder: 'Filter by Address...',
+          type: 'text'
+        }, {
+          id: 'birthMonth',
+          title:  'Birth Month',
+          placeholder: 'Filter by Birth Month...',
+          type: 'select',
+          queries: [{
+            id: 'month1',
+            value: 'January'
+          }, {
+            id: 'month2',
+            value: 'February'
+          }, {
+            id: 'month3',
+            value: 'March'
+          }, {
+            id: 'month4',
+            value: 'April'
+          }, {
+            id: 'month5',
+            value: 'May'
+          }, {
+            id: 'month6',
+            value: 'June'
+          }, {
+            id: 'month7',
+            value: 'July'
+          }, {
+            id: 'month8',
+            value: 'August'
+          }, {
+            id: 'month9',
+            value: 'September'
+          },{
+            id: 'month10',
+            value: 'October'
+          }, {
+            id: 'month11',
+            value: 'November'
+          }, {
+            id: 'month12',
+            value: 'December'
+          }]
+        }] as FilterField[],
+        resultsCount: 5,
+        appliedFilters: []
+      } as FilterConfig,
+
+      sortConfig: {
+        fields: [{
+          id: 'name',
+          title: 'Name',
+          sortType: 'alpha'
+        }, {
+          id: 'age',
+          title: 'Age',
+          sortType: 'numeric'
+        }, {
+          id: 'address',
+          title: 'Address',
+          sortType: 'alpha'
+        }, {
+          id: 'birthMonth',
+          title: 'Birth Month',
+          sortType: 'alpha'
+        }],
+        isAscending: this.isAscendingSort
+      } as SortConfig,
+
+      viewsConfig: {
+        views: [{
+          id: 'listView',
+          title: 'List View',
+          iconClass: 'fa fa-th-list'
+        }, {
+          id: 'tableView',
+          title: 'Table View',
+          iconClass: 'fa fa-table'
+        }],
+      } as ViewsConfig
+    } as ToolbarConfig;
+  });
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BsDropdownModule.forRoot(),
+        BrowserAnimationsModule,
+        FormsModule,
+        TooltipModule.forRoot(),
+        SearchHighlightModule
+      ],
+      declarations: [
+        ToolbarComponent, FilterFieldsComponent,
+        FilterResultsComponent, SortComponent
+      ],
+      providers: [BsDropdownConfig, TooltipConfig]
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(ToolbarComponent);
+        comp = fixture.componentInstance;
+        comp.config = config;
+        fixture.detectChanges();
+      });
+  }));
+
+  // Filter tests
+
+  it('should have correct number of filter fields', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let fields = fixture.debugElement.queryAll(By.css('.filter-field'));
+    expect(fields.length).toBe(4);
+  });
+
+  it('should have correct number of results', function () {
+    let results = fixture.debugElement.query(By.css('h5'));
+    expect(results).toBeNull();
+
+    config.filterConfig.appliedFilters = [{
+      field: {
+        id: 'address',
+        title: 'Address'
+      },
+      value: 'New York'
+    }] as Filter[];
+    config.filterConfig.resultsCount = 10;
+    fixture.detectChanges();
+
+    results = fixture.debugElement.query(By.css('h5'));
+    expect(results).not.toBeNull();
+    expect(results.nativeElement.textContent.trim().slice(0, '10 Results'.length)).toBe('10 Results');
+  });
+
+  it ('should add a dropdown select when a select type is chosen', function() {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let filterSelect = fixture.debugElement.query(By.css('.filter-select'));
+    let fields = fixture.debugElement.queryAll(By.css('.filter-field'));
+
+    expect(filterSelect).toBeNull();
+    fields[3].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    filterSelect = fixture.debugElement.query(By.css('.filter-select'));
+    expect(filterSelect).not.toBeNull();
+
+    /* Todo: ngx-bootstrap no longer renders children for this test?
+    let items = filterSelect.queryAll(By.css('li'));
+    expect(items.length).toBe(config.filterConfig.fields[3].queries.length + 1); // +1 for the null value
+    */
+  });
+
+  it ('should clear a filter when the close button is clicked', function () {
+    let closeButtons = fixture.debugElement.queryAll(By.css('.pficon-close'));
+    expect(closeButtons.length).toBe(0);
+
+    config.filterConfig.appliedFilters = [{
+      field: {
+        id: 'address',
+        title: 'Address'
+      },
+      value: 'New York'
+    }] as Filter[];
+    fixture.detectChanges();
+
+    closeButtons = fixture.debugElement.queryAll(By.css('.pficon-close'));
+    expect(closeButtons.length).toBe(1);
+
+    closeButtons[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    closeButtons = fixture.debugElement.queryAll(By.css('.pficon-close'));
+    expect(closeButtons.length).toBe(0);
+  });
+
+  it ('should clear all filters when the clear all filters button is clicked', function () {
+    let activeFilters = fixture.debugElement.queryAll(By.css('.active-filter'));
+    let clearButton = fixture.debugElement.query(By.css('.clear-filters'));
+    expect(activeFilters.length).toBe(0);
+    expect(clearButton).toBeNull();
+
+    config.filterConfig.appliedFilters = [{
+      field: {
+        id: 'address',
+        title: 'Address'
+      },
+      value: 'New York'
+    }] as Filter[];
+    fixture.detectChanges();
+
+    activeFilters = fixture.debugElement.queryAll(By.css('.active-filter'));
+    clearButton = fixture.debugElement.query(By.css('.clear-filters'));
+    expect(activeFilters.length).toBe(1);
+    expect(clearButton).not.toBeNull();
+
+    clearButton.triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    activeFilters = fixture.debugElement.queryAll(By.css('.active-filter'));
+    clearButton = fixture.debugElement.query(By.css('.clear-filters'));
+    expect(activeFilters.length).toBe(0);
+    expect(clearButton).toBeNull();
+  });
+
+  it ('should not show filters when a filter config is not supplied', function () {
+    let filter = fixture.debugElement.queryAll(By.css('.filter-pf'));
+    expect(filter.length).toBe(1);
+
+    config.filterConfig = undefined;
+    comp.config = config;
+    fixture.detectChanges();
+
+    filter = fixture.debugElement.queryAll(By.css('.filter-pf'));
+    expect(filter.length).toBe(0);
+  });
+
+  // Sort Tests
+
+  it('should have correct number of sort fields', () => {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let elements = fixture.debugElement.queryAll(By.css('.sort-pf .sort-field'));
+    expect(elements.length).toBe(4);
+  });
+
+  it('should have default to the first sort field', () => {
+    let results = fixture.debugElement.query(By.css('.sort-pf .dropdown-toggle'));
+    expect(results).not.toBeNull();
+    expect(results.nativeElement.textContent.trim().slice(0, 'Name'.length)).toBe('Name');
+  });
+
+  it('should default to ascending sort', function () {
+    let sortIcon = fixture.debugElement.query(By.css('.sort-pf .fa-sort-alpha-asc'));
+    expect(sortIcon).not.toBeNull();
+  });
+
+  it('should update the current sort when one is selected', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let results = fixture.debugElement.query(By.css('.sort-pf .dropdown-toggle'));
+    let fields = fixture.debugElement.queryAll(By.css('.sort-pf .sort-field'));
+
+    expect(results).not.toBeNull();
+    expect(results.nativeElement.textContent.trim().slice(0, 'Name'.length)).toBe('Name');
+    expect(fields.length).toBe(4);
+
+    fields[2].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    results = fixture.debugElement.query(By.css('.sort-pf .dropdown-toggle'));
+    expect(results.nativeElement.textContent.trim().slice(0, 'Address'.length))
+        .toBe('Address');
+  });
+
+  it('should update the direction icon when the sort type changes', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let results = fixture.debugElement.query(By.css('.sort-pf .dropdown-toggle'));
+    let fields = fixture.debugElement.queryAll(By.css('.sort-pf .sort-field'));
+    let sortIcon = fixture.debugElement.query(By.css('.sort-pf .fa-sort-alpha-asc'));
+
+    expect(results).not.toBeNull();
+    expect(results.nativeElement.textContent.trim().slice(0, 'Name'.length)).toBe('Name');
+    expect(fields.length).toBe(4);
+    expect(sortIcon).not.toBeNull();
+
+    fields[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    results = fixture.debugElement.query(By.css('.sort-pf .dropdown-toggle'));
+    sortIcon = fixture.debugElement.query(By.css('.sort-pf .fa-sort-numeric-asc'));
+    expect(results).not.toBeNull();
+    expect(results.nativeElement.textContent.trim().slice(0, 'Age'.length)).toBe('Age');
+    expect(sortIcon).not.toBeNull();
+
+  });
+
+  it('should reverse the sort direction when the direction button is clicked', function () {
+    let sortButton = fixture.debugElement.query(By.css('.sort-pf .btn.btn-link'));
+    let sortIcon = fixture.debugElement.query(By.css('.sort-pf .fa-sort-alpha-asc'));
+    expect(sortButton).not.toBeNull();
+    expect(sortIcon).not.toBeNull();
+
+    sortButton.triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    sortIcon = fixture.debugElement.query(By.css('.sort-pf .fa-sort-alpha-desc'));
+    expect(sortIcon).not.toBeNull();
+  });
+
+  it ('should notify when a new sort field is chosen', function(done) {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let fields = fixture.debugElement.queryAll(By.css('.sort-pf .sort-field'));
+
+    comp.onSortChange.subscribe((data: SortEvent) => {
+      expect(data.field).toBe(config.sortConfig.fields[1]);
+      done();
+    });
+
+    expect(fields.length).toBe(4);
+
+    fields[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+  });
+
+  it ('should notify when the sort direction changes', function(done) {
+    let sortButton = fixture.debugElement.query(By.css('.sort-pf .btn.btn-link'));
+
+    comp.onSortChange.subscribe((data: SortEvent) => {
+      expect(data.isAscending).toBe(false);
+      done();
+    });
+
+    expect(sortButton).not.toBeNull();
+
+    sortButton.triggerEventHandler('click', {});
+    fixture.detectChanges();
+  });
+
+  it ('should not show sort when a sort config is not supplied', function () {
+    let sort = fixture.debugElement.query(By.css('.sort-pf'));
+    expect(sort).not.toBeNull();
+
+    config.sortConfig = undefined;
+    comp.config = config;
+    fixture.detectChanges();
+
+    sort = fixture.debugElement.query(By.css('.sort-pf'));
+    expect(sort).toBeNull();
+  });
+
+  // View tests
+
+  it ('should show the correct view selection buttons', function () {
+    let listSelectora = fixture.debugElement.queryAll(By.css('.toolbar-pf-view-selector .btn-link'));
+    expect(listSelectora.length).toBe(2);
+
+    expect(fixture.debugElement.query(By.css('.fa-th-list'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('.fa-table'))).not.toBeNull();
+  });
+
+  it ('should show the currently selected view', function () {
+    let viewSelector = fixture.debugElement.query(By.css('.toolbar-pf-view-selector'));
+    let active = fixture.debugElement.queryAll(By.css('.active'));
+    expect(viewSelector).not.toBeNull();
+    expect(active.length).toBe(1);
+
+    config.viewsConfig.currentView = config.viewsConfig.views[0];
+    fixture.detectChanges();
+
+    active = fixture.debugElement.queryAll(By.css('.active'));
+    expect(active.length).toBe(1);
+  });
+
+  it ('should update the currently selected view when a view selector clicked', function () {
+    let active = fixture.debugElement.queryAll(By.css('.active'));
+    let viewSelector = fixture.debugElement.query(By.css('.toolbar-pf-view-selector'));
+    let listSelectora = fixture.debugElement.queryAll(By.css('.toolbar-pf-view-selector .btn-link'));
+
+    expect(viewSelector).not.toBeNull();
+    expect(active.length).toBe(1);
+    expect(listSelectora.length).toBe(2);
+
+    listSelectora[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    active = fixture.debugElement.queryAll(By.css('.active'));
+    expect(active.length).toBe(1);
+  });
+
+  it ('should call the callback function when a view selector clicked', function (done) {
+    let listSelectors = fixture.debugElement.queryAll(By.css('.toolbar-pf-view-selector .btn-link'));
+    expect(listSelectors.length).toBe(2);
+
+    let view: View;
+    comp.onViewSelect.subscribe((data: View) => {
+      view = data;
+      done();
+    });
+
+    listSelectors[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(view).not.toBeNull();
+  });
+
+  it ('should not show view selectors when no viewsConfig is supplied', function () {
+    let viewSelector = fixture.debugElement.query(By.css('.toolbar-pf-view-selector'));
+    expect(viewSelector).not.toBeNull();
+
+    config.viewsConfig = undefined;
+    fixture.detectChanges();
+
+    viewSelector = fixture.debugElement.query(By.css('.toolbar-pf-view-selector'));
+    expect(viewSelector).toBeNull();
+  });
+
+  // Action tests
+
+  it('should have correct number of primary actions', function () {
+    let fields = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .primary-action'));
+    expect(fields.length).toBe(2);
+  });
+
+  it('should have correct number of secondary actions', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let fields = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .secondary-action'));
+    expect(fields.length).toBe(6);
+  });
+
+  it('should have correct number of separators', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let fields = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .divider'));
+    expect(fields.length).toBe(1);
+  });
+
+  it('should correctly disable actions', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let fields = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .disabled'));
+    expect(fields.length).toBe(1);
+  });
+
+  it('should not show more actions menu when there are no more actions', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let menus = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .fa-ellipsis-v'));
+    expect(menus.length).toBe(1);
+
+    config.actionsConfig.moreActions.length = 0;
+    fixture.detectChanges();
+
+    menus = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .fa-ellipsis-v'));
+    expect(menus.length).toBe(0);
+  });
+
+  it('should call the action function with the appropriate action when an action is clicked', function (done) {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let primaryActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .primary-action'));
+    let moreActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .secondary-action'));
+    expect(primaryActions.length).toBe(2);
+    expect(moreActions.length).toBe(6);
+
+    let action: Action;
+    comp.onActionSelect.subscribe((data: Action) => {
+      action = data;
+      done();
+    });
+
+    primaryActions[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(action).toBe(config.actionsConfig.primaryActions[0]);
+
+    moreActions[3].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(action).toBe(config.actionsConfig.moreActions[3]);
+  });
+
+  it('should not call the action function when a disabled action is clicked', function (done) {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let primaryActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .primary-action'));
+    let moreActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .secondary-action'));
+    expect(primaryActions.length).toBe(2);
+    expect(moreActions.length).toBe(6);
+
+    let action: Action = null;
+    comp.onActionSelect.subscribe((data: Action) => {
+      action = data;
+      done();
+    });
+
+    moreActions[2].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(action).toBeNull();
+
+    primaryActions[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(action).toBe(config.actionsConfig.primaryActions[1]);
+
+    config.actionsConfig.primaryActions[1].disabled = true;
+    fixture.detectChanges();
+    action = null;
+
+    primaryActions[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    expect(action).toBeNull();
+  });
+
+  it('should not show action components when an action config is not supplied', function () {
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+    let primaryActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .primary-action'));
+    let moreActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .secondary-action'));
+    expect(primaryActions.length).toBe(2);
+    expect(moreActions.length).toBe(6);
+
+    config.actionsConfig = undefined;
+    comp.config = config;
+    fixture.detectChanges();
+
+    primaryActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .primary-action'));
+    moreActions = fixture.debugElement.queryAll(By.css('.toolbar-pf-actions .secondary-action'));
+    expect(primaryActions.length).toBe(0);
+    expect(moreActions.length).toBe(0);
+  });
+});

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,0 +1,165 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
+
+import * as _ from 'lodash';
+
+import { Action } from '../models/action';
+import { Filter } from '../filters/filter';
+import { FilterEvent } from '../filters/filter-event';
+import { SortEvent } from '../sort/sort-event';
+import { ToolbarConfig } from './toolbar-config';
+import { View } from '../models/view';
+
+/**
+ * Standard toolbar component. Includes filtering and view selection capabilities
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-toolbar',
+  styleUrls: ['./toolbar.component.less'],
+  templateUrl: './toolbar.component.html'
+})
+export class ToolbarComponent implements OnInit {
+  @Input() config: ToolbarConfig;
+  @Input() actionsTemplate: TemplateRef<any>;
+  @Input() viewsTemplate: TemplateRef<any>;
+
+  @Output('onActionSelect') onActionSelect = new EventEmitter();
+  @Output('onFilterFieldSelect') onFilterFiledSelect = new EventEmitter();
+  @Output('onFilterChange') onFilterChange = new EventEmitter();
+  @Output('onFilterTypeAhead') onFilterTypeAhead = new EventEmitter();
+  @Output('onSortChange') onSortChange = new EventEmitter();
+  @Output('onViewSelect') onViewSelect = new EventEmitter();
+
+  defaultConfig: ToolbarConfig = {} as ToolbarConfig;
+  prevConfig: ToolbarConfig;
+
+  constructor() {
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    this.setupConfig();
+  }
+
+  ngDoCheck(): void {
+    // Do a deep compare on config
+    if (!_.isEqual(this.config, this.prevConfig)) {
+      this.setupConfig();
+    }
+  }
+
+  setupConfig(): void {
+    if (this.config !== undefined) {
+      _.defaults(this.config, this.defaultConfig);
+    } else {
+      this.config = _.cloneDeep(this.defaultConfig);
+    }
+
+    if (this.config && this.config.filterConfig
+        && this.config.filterConfig.appliedFilters === undefined) {
+      this.config.filterConfig.appliedFilters = [];
+    }
+    if (this.config && this.config.sortConfig && this.config.sortConfig.fields === undefined) {
+      this.config.sortConfig.fields = [];
+    }
+    if (this.config.sortConfig !== undefined && this.config.sortConfig.show === undefined) {
+      this.config.sortConfig.show = true;
+    }
+    if (this.config && this.config.viewsConfig && this.config.viewsConfig.views === undefined) {
+      this.config.viewsConfig.views = [];
+    }
+    if (this.config && this.config.viewsConfig
+        && this.config.viewsConfig.currentView === undefined) {
+      this.config.viewsConfig.currentView = this.config.viewsConfig.views[0];
+    }
+  }
+
+  // Action functions
+
+  handleAction(action: Action): void {
+    if (action && action.disabled !== true) {
+      this.onActionSelect.emit(action);
+    }
+  }
+
+  // Filter functions
+
+  clearFilter($event: Filter[]): void {
+    this.config.filterConfig.appliedFilters = $event;
+    this.onFilterChange.emit({
+      appliedFilters: $event
+    } as FilterEvent);
+  }
+
+  filterAdded($event: FilterEvent): void {
+    let newFilter = {
+      field: $event.field,
+      query: $event.query,
+      value: $event.value
+    } as Filter;
+
+    if (!this.filterExists(newFilter)) {
+      if (newFilter.field.type === 'select') {
+        this.enforceSingleSelect(newFilter);
+      }
+      this.config.filterConfig.appliedFilters.push(newFilter);
+      $event.appliedFilters = this.config.filterConfig.appliedFilters;
+      this.onFilterChange.emit($event);
+    }
+  }
+  
+  filterExists(filter: Filter): boolean {
+    let foundFilter = _.find(this.config.filterConfig.appliedFilters, {
+      field: filter.field,
+      query: filter.query,
+      value: filter.value
+    });
+    return foundFilter !== undefined;
+  }
+
+  handleFilterFieldSelect($event: FilterEvent): void {
+    this.onFilterFiledSelect.emit($event);
+  }
+
+  handleFilterTypeAhead($event: FilterEvent) {
+    this.onFilterTypeAhead.emit($event);
+  }
+
+  // Sort functions
+
+  sortChange($event: SortEvent): void {
+    this.onSortChange.emit($event);
+  }
+
+  // View functions
+
+  isViewSelected(view: View): boolean {
+    return this.config.viewsConfig && (this.config.viewsConfig.currentView.id === view.id);
+  }
+
+  submit($event: any): void {
+    $event.preventDefault();
+  }
+
+  viewSelected (view: View): void {
+    this.config.viewsConfig.currentView = view;
+    if (!view.disabled) {
+      this.onViewSelect.emit(view);
+    }
+  }
+
+  // Private
+
+  private enforceSingleSelect(filter: Filter): void {
+    _.remove(this.config.filterConfig.appliedFilters, {title: filter.field.title});
+  }
+}

--- a/src/app/toolbar/toolbar.module.ts
+++ b/src/app/toolbar/toolbar.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { FiltersModule } from '../filters/filters.module';
+import { SortModule } from '../sort/sort.module';
+import { ToolbarComponent } from './toolbar.component';
+import { ToolbarConfig } from './toolbar-config';
+
+export {
+  ToolbarConfig
+}
+
+@NgModule({
+  imports: [ BsDropdownModule, CommonModule, FiltersModule, SortModule ],
+  declarations: [ ToolbarComponent ],
+  exports: [ ToolbarComponent ],
+  providers: [ BsDropdownConfig ]
+})
+export class ToolbarModule { }

--- a/src/demo/app-routing.module.ts
+++ b/src/demo/app-routing.module.ts
@@ -6,7 +6,7 @@ import { SampleExampleComponent } from '../app/sample/examples/sample-example.co
 import { SearchHighlightExampleComponent } from '../app/pipes/examples/search-highlight-example.component';
 import { SortExampleComponent } from '../app/sort/examples/sort-example.component';
 import { ToastNotificationExampleComponent } from '../app/notification/examples/toast-notification-example.component';
-import { ToastNotificationListExampleComponent } from '../app/notification/examples/toast-notification-list-example.component';
+import { ToolbarExampleComponent } from '../app/toolbar/examples/toolbar-example.component';
 import { WelcomeComponent } from './components/welcome.component';
 
 const routes: Routes = [{
@@ -28,7 +28,10 @@ const routes: Routes = [{
   }, {
     path: 'toastnotification',
     component: ToastNotificationExampleComponent
-  }];
+  }, {
+    path: 'toolbar',
+    component: ToolbarExampleComponent
+}];
 
 @NgModule({
   imports: [ RouterModule.forRoot(routes, {useHash: true}) ],

--- a/src/demo/app.component.html
+++ b/src/demo/app.component.html
@@ -25,6 +25,12 @@
         <li>
           <a routerLink="/sort" routerLinkActive="active">Sort</a>
         </li>
+        <li>
+          <a routerLink="/toastnotification" routerLinkActive="active">Toast Notification</a>
+        </li>
+        <li>
+          <a routerLink="/toolbar" routerLinkActive="active">Toolbar Component</a>
+        </li>
       </ul>
       <hr/>
       <h3>Directives</h3>
@@ -37,9 +43,6 @@
       <ul>
         <li>
           <a routerLink="/searchhighlight" routerLinkActive="active">Search Highlight</a>
-        </li>
-        <li>
-          <a routerLink="/toastnotification" routerLinkActive="active">Toast Notification Component</a>
         </li>
       </ul>
     </div>

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -12,10 +12,11 @@ import { AppRoutingModule } from './app-routing.module';
 // Main areas
 //  import example modules
 import { FilterExampleModule } from '../app/filters/examples/filter-example.module';
+import { NotificationExampleModule } from '../app/notification/examples/notification-example.module';
 import { SampleExampleModule } from '../app/sample/examples/sample-example.module';
 import { SearchHighlightExampleModule } from '../app/pipes/examples/search-highlight-example.module';
 import { SortExampleModule } from '../app/sort/examples/sort-example.module';
-import { NotificationExampleModule } from '../app/notification/examples/notification-example.module';
+import { ToolbarExampleModule } from '../app/toolbar/examples/toolbar-example.module';
 import { WelcomeComponent } from './components/welcome.component';
 
 @NgModule({
@@ -28,7 +29,8 @@ import { WelcomeComponent } from './components/welcome.component';
     NotificationExampleModule,
     SampleExampleModule,
     SearchHighlightExampleModule,
-    SortExampleModule
+    SortExampleModule,
+    ToolbarExampleModule
   ],
   declarations: [
     AppComponent,

--- a/tslint.json
+++ b/tslint.json
@@ -74,7 +74,7 @@
     ],
     "max-line-length": [
       true,
-      100
+      120
     ],
     "no-require-imports": false,
     "no-trailing-whitespace": false,


### PR DESCRIPTION
Added toolbar component which uses the sort, filter, and filter fields as sub-components.

Refactored some filter attribute names to better fit/clarify type-ahead functionality and added default config.

Example:
https://rawgit.com/dlabrecq/patternfly-ng/toolbar-dist/dist-demo/

Screen shot:
![screen shot 2017-06-14 at 5 55 31 pm](https://user-images.githubusercontent.com/17481322/27156397-e717a682-512a-11e7-9c9f-b366a5f2b8ab.png)
