### PR TITLE
Added remaining chars directive

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,9 @@ export { NotificationService } from './src/app/notification/notification.service
 export { ToastNotificationComponent } from './src/app/notification/toast-notification.component';
 export { ToastNotificationListComponent } from './src/app/notification/toast-notification-list.component';
 
+// Remaining Chars
+export { RemainingCharsDirective } from './src/app/remaining-chars/remaining-chars.directive';
+
 // Sample
 export { SampleModule } from './src/app/sample/sample.module';
 

--- a/src/app/remaining-chars/examples/remaining-chars-example.component.html
+++ b/src/app/remaining-chars/examples/remaining-chars-example.component.html
@@ -1,0 +1,93 @@
+<div class="padding-15">
+  <div class="row padding-bottom-15">
+    <div class="col-xs-12">
+      <h4>Remaining Chars Directive Example</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="example-container">
+    <h3>Max limit: 20, warn when 5 or less remaining, disable button after max limit</h3>
+    <div class="row">
+      <div class="col-md-4">
+        <div class="form-group">
+          <label class="sr-only" for="example1">Example 1</label>
+          <textarea class="form-control" id="example1" name="example1" rows="5"
+                    placeholder="Type in your message"
+                    [charsMaxLimit]="20"
+                    [charsRemainingElement]="remainingCountElement1"
+                    [charsRemainingWarning]="5"
+                    (onOverCharsMaxLimit)="handleOverCharsMaxLimit($event, 'example1')"
+                    (onUnderCharsMaxLimit)="handleUnderCharsMaxLimit($event, 'example1')"
+                    (ngModel)="example1"
+                    pfng-remaining-chars>Initial text</textarea>
+        </div>
+        <span class="pull-right chars-remaining-pf">
+        <span #remainingCountElement1></span>
+        <button class="btn btn-default" onclick="return false"
+                [disabled]="charsMaxLimitExceeded['example1']">Post New Message</button>
+      </span>
+      </div>
+    </div>
+    <h3>Max limit: 10, warn when 2 or less remaining, block input after max limit</h3>
+    <div class="row">
+      <div class="col-md-4">
+        <form>
+          <div class="form-group">
+            <label class="sr-only" for="example2">Example 2</label>
+            <textarea class="form-control" id="example2" name="example2" rows="5"
+                      placeholder="Type in your message"
+                      [blockInputAtMaxLimit]="true"
+                      [charsMaxLimit]="10"
+                      [charsRemainingElement]="remainingCountElement2"
+                      [charsRemainingWarning]="2"
+                      (onOverCharsMaxLimit)="handleOverCharsMaxLimit($event, 'example2')"
+                      (onUnderCharsMaxLimit)="handleUnderCharsMaxLimit($event, 'example2')"
+                      (ngModel)="example2"
+                      pfng-remaining-chars></textarea>
+          </div>
+          <span class="pull-left">
+          <button class="btn btn-default" onclick="return false;">Submit</button>
+        </span>
+          <span class="pull-right chars-remaining-pf padding-top-3">
+          <span #remainingCountElement2></span>
+        </span>
+        </form>
+      </div>
+    </div>
+    <h3>Max limit: 10, warn when 5 or less remaining, block input after max limit</h3>
+    <div class="row">
+      <div class="col-md-4">
+        <label class="sr-only" for="example3">Example 3</label>
+        <input id="example3" name="example3" type="text"
+               [blockInputAtMaxLimit]="true"
+               [charsMaxLimit]="10"
+               [charsRemainingElement]="remainingCountElement3"
+               [charsRemainingWarning]="5"
+               (onOverCharsMaxLimit)="handleOverCharsMaxLimit($event, 'example3')"
+               (onUnderCharsMaxLimit)="handleUnderCharsMaxLimit($event, 'example3')"
+               (ngModel)="example3"
+               pfng-remaining-chars>
+        <span class="chars-remaining-pf padding-left-5">
+          <span #remainingCountElement3></span>
+          <span>Remaining</span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset style="border: 1px black;">
+      <tab heading="html">
+        <include-content src="/src/app/remaining-chars/examples/remaining-chars-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="/src/app/remaining-chars/examples/remaining-chars-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/remaining-chars/examples/remaining-chars-example.component.less
+++ b/src/app/remaining-chars/examples/remaining-chars-example.component.less
@@ -1,0 +1,19 @@
+@import (reference) "../../../assets/stylesheets/patternfly-ng";
+
+.chars-remaining-pf {
+  > span {
+    vertical-align: middle;
+  }
+}
+
+.example-container {
+  width: 1180px;
+}
+
+textarea {
+  resize: none;
+}
+
+.vert-align {
+  vertical-align: middle;
+}

--- a/src/app/remaining-chars/examples/remaining-chars-example.component.ts
+++ b/src/app/remaining-chars/examples/remaining-chars-example.component.ts
@@ -1,0 +1,45 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'remaining-chars-example',
+  styleUrls: ['./remaining-chars-example.component.less'],
+  templateUrl: './remaining-chars-example.component.html'
+})
+export class RemainingCharsExampleComponent implements OnInit {
+  charsMaxLimitExceeded: any = {
+    'example1': false,
+    'example2': false,
+    'example3': false
+  }
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  // Actions
+
+  /**
+   * Handle over chars max limit event
+   *
+   * @param $event The number of remaining chars
+   */
+  handleOverCharsMaxLimit($event: number, id: string): void {
+    this.charsMaxLimitExceeded[id] = true;
+  }
+
+  /**
+   * Handle under chars max limit event
+   *
+   * @param $event The number of remaining chars
+   */
+  handleUnderCharsMaxLimit($event: number, id: string): void {
+    this.charsMaxLimitExceeded[id] = false;
+  }
+}

--- a/src/app/remaining-chars/examples/remaining-chars-example.module.ts
+++ b/src/app/remaining-chars/examples/remaining-chars-example.module.ts
@@ -1,0 +1,21 @@
+import { NgModule }  from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
+
+import { DemoComponentsModule } from '../../../demo/components/demo-components.module';
+import { RemainingCharsModule } from '../remaining-chars.module';
+import { RemainingCharsExampleComponent } from './remaining-chars-example.component';
+
+@NgModule({
+  declarations: [ RemainingCharsExampleComponent ],
+  imports: [
+    CommonModule,
+    DemoComponentsModule,
+    RemainingCharsModule,
+    TabsModule.forRoot(),
+  ],
+  providers: [ TabsetConfig ]
+})
+export class RemainingCharsExampleModule {
+  constructor() {}
+}

--- a/src/app/remaining-chars/remaining-chars.directive.ts
+++ b/src/app/remaining-chars/remaining-chars.directive.ts
@@ -1,0 +1,124 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnInit,
+  Output,
+  Renderer2
+} from '@angular/core';
+
+import * as _ from 'lodash';
+
+/**
+ * Remaining Characters component for showing a characters remaining count and triggering warning and error
+ * behavior when passing specified thresholds.  When the <code>charsRemainingWarning</code> threshold is passed,
+ * the <code>chars-warn-remaining-pf</code> css class is applied to the <code>charsRemainingElement</code>, which by
+ * default, turns the remaining count number <font color='red'>red</font>. By default, characters may be entered into
+ * the text field after the <code>charsMaxLimit</code> limit has been reached, the remaining count number will become a
+ * negative value. Setting the <code>blockInputAtMaxLimit</code> to <em>true</em>, will block additional input into the
+ * text field after the max has been reached; additionally a right-click 'paste' will only paste characters until the
+ * maximum character limit is reached.
+ *
+ * blockInputAtMaxLimit - If true, no more characters can be entered into the text field
+ * charsMaxLimit - Number representing the maximum number of characters allowed
+ * charsRemainingElement - The ElementRef used to display the 'characters-remaining' count
+ * charsRemainingWarning - Number of remaining characters to warn upon
+ */
+@Directive({
+  selector: '[pfng-remaining-chars]'
+})
+export class RemainingCharsDirective implements OnInit {
+  @Input() blockInputAtMaxLimit: boolean;
+  @Input() charsMaxLimit: number = 100;
+  @Input() charsRemainingElement: any;
+  @Input() charsRemainingWarning: number = 5;
+
+  @Output('onOverCharsMaxLimit') onOverCharsMaxLimit = new EventEmitter();
+  @Output('onUnderCharsMaxLimit') onUnderCharsMaxLimit = new EventEmitter();
+
+  remainingChars: number = 0;
+
+  constructor(private el: ElementRef,
+              private renderer: Renderer2) {
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    this.remainingChars = this.charsMaxLimit;
+    this.checkRemainingChars();
+  }
+
+  // Actions
+
+  /**
+   * Handle key events
+   *
+   * Note: Using the keyup event Vs keypress to include backspace/delete
+   *
+   * @param $event
+   */
+  @HostListener('keyup', ['$event']) handleKeypress($event: KeyboardEvent): void {
+    // Once the charsMaxLimit has been met or exceeded, prevent all keypresses from working
+    if (this.blockInputAtMaxLimit && this.el.nativeElement.value.length >= this.charsMaxLimit) {
+      // Except backspace
+      if ($event.keyCode !== 8) {
+        $event.preventDefault();
+      }
+    }
+    this.checkRemainingChars();
+  }
+
+  // Private
+
+  /**
+   * Helper to check remaining characters
+   */
+  private checkRemainingChars(): void {
+    this.setRemainingChars();
+    this.setRemainingCharsWarning();
+    this.emitRemainingCharsEvent();
+  }
+
+  /**
+   * Emit remaining characters event
+   */
+  private emitRemainingCharsEvent(): void {
+    if (this.remainingChars <= 0) {
+      this.onOverCharsMaxLimit.emit(this.remainingChars);
+    } else {
+      this.onUnderCharsMaxLimit.emit(this.remainingChars);
+    }
+  }
+
+  /**
+   * Set remaining characters
+   */
+  private setRemainingChars(): void {
+    let charsLength = this.el.nativeElement.value.length;
+
+    // Trim if blockInputAtMaxLimit and over limit
+    if (this.blockInputAtMaxLimit && charsLength > this.charsMaxLimit) {
+      this.el.nativeElement.value = this.el.nativeElement.value.substring(0, this.charsMaxLimit);
+      charsLength = this.el.nativeElement.value.length;
+    }
+    this.remainingChars = this.charsMaxLimit - charsLength;
+  }
+
+  /**
+   * Set remaining characters warning
+   */
+  private setRemainingCharsWarning(): void {
+    if (this.charsRemainingElement !== undefined) {
+      this.charsRemainingElement.innerText = this.remainingChars;
+
+      if (this.remainingChars <= this.charsRemainingWarning) {
+        this.renderer.addClass(this.charsRemainingElement, 'chars-warn-remaining-pf');
+      } else {
+        this.renderer.removeClass(this.charsRemainingElement, 'chars-warn-remaining-pf');
+      }
+    }
+  }
+}

--- a/src/app/remaining-chars/remaining-chars.module.ts
+++ b/src/app/remaining-chars/remaining-chars.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { RemainingCharsDirective } from './remaining-chars.directive';
+
+@NgModule({
+  imports: [ CommonModule, FormsModule ],
+  declarations: [ RemainingCharsDirective ],
+  exports: [ RemainingCharsDirective ]
+})
+export class RemainingCharsModule { }

--- a/src/demo/app-routing.module.ts
+++ b/src/demo/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { EmptyStateExampleComponent } from '../app/empty-state/examples/empty-state-example.component';
 import { FilterExampleComponent } from '../app/filters/examples/filter-example.component';
+import { RemainingCharsExampleComponent } from '../app/remaining-chars/examples/remaining-chars-example.component';
 import { SampleExampleComponent } from '../app/sample/examples/sample-example.component';
 import { SearchHighlightExampleComponent } from '../app/pipes/examples/search-highlight-example.component';
 import { SortExampleComponent } from '../app/sort/examples/sort-example.component';
@@ -20,6 +21,9 @@ const routes: Routes = [{
   }, {
     path: 'filters',
     component: FilterExampleComponent
+  }, {
+    path: 'remainingchars',
+    component: RemainingCharsExampleComponent
   }, {
     path: 'sample',
     component: SampleExampleComponent

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -1,4 +1,4 @@
-//import './rxjs-extensions';
+// import './rxjs-extensions';
 
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
@@ -14,6 +14,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { EmptyStateExampleModule } from '../app/empty-state/examples/empty-state-example.module';
 import { FilterExampleModule } from '../app/filters/examples/filter-example.module';
 import { NotificationExampleModule } from '../app/notification/examples/notification-example.module';
+import { RemainingCharsExampleModule } from '../app/remaining-chars/examples/remaining-chars-example.module';
 import { SampleExampleModule } from '../app/sample/examples/sample-example.module';
 import { SearchHighlightExampleModule } from '../app/pipes/examples/search-highlight-example.module';
 import { SortExampleModule } from '../app/sort/examples/sort-example.module';
@@ -29,6 +30,7 @@ import { WelcomeComponent } from './components/welcome.component';
     FormsModule,
     HttpModule,
     NotificationExampleModule,
+    RemainingCharsExampleModule,
     SampleExampleModule,
     SearchHighlightExampleModule,
     SortExampleModule,


### PR DESCRIPTION
Added remaining chars directive.

Note: the ngx-widgets version was implemented as a component, but I rewrote this as a directive to better expose the underlying text area and/or input elements.

Example:
https://rawgit.com/dlabrecq/patternfly-ng/remaining-chars-dist/dist-demo/

![screen shot 2017-06-15 at 4 08 02 pm](https://user-images.githubusercontent.com/17481322/27200070-5750c1de-51e6-11e7-8ee5-47218cea9382.png)


