### PR TITLE
Added list-view

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,14 @@ export { FilterResultsComponent } from './src/app/filters/filter-results.compone
 export { FilterQuery } from './src/app/filters/filter-query';
 export { FiltersModule } from './src/app/filters/filters.module';
 
+// List View
+export { ListViewActionsComponent } from './src/app/list-view/list-view-actions.component';
+export { ListViewConfig } from './src/app/list-view/list-view-config';
+export { ListViewComponent } from './src/app/list-view/list-view.component';
+export { ListViewCompoundToggleComponent } from './src/app/list-view/list-view-compound-toggle.component';
+export { ListViewEvent } from './src/app/list-view/list-view-event';
+export { ListViewModule } from './src/app/list-view/list-view.module';
+
 // Models
 export { Action } from './src/app/models/action';
 export { ActionsConfig } from './src/app/models/actions-config';

--- a/src/app/list-view/examples/basic-content.component.html
+++ b/src/app/list-view/examples/basic-content.component.html
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="col-md-9">
+    <dl class="dl-horizontal">
+      <dt>Host</dt>
+      <dd>{{item.city}}</dd>
+      <dt>Admin</dt>
+      <dd>{{item.name}}</dd>
+      <dt>Time</dt>
+      <dd>January 15, 2016 10:45:11 AM</dd>
+      <dt>Severity</dt>
+      <dd>Warning</dd>
+      <dt>Cluster</dt>
+      <dd>Cluster 1</dd>
+    </dl>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/app/list-view/examples/basic-content.component.ts
+++ b/src/app/list-view/examples/basic-content.component.ts
@@ -1,0 +1,24 @@
+import {
+  Component,
+  Input,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'basic-content',
+  templateUrl: './basic-content.component.html'
+})
+export class BasicContentComponent implements OnInit {
+  @Input() item: any;
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+}

--- a/src/app/list-view/examples/clusters-content.component.html
+++ b/src/app/list-view/examples/clusters-content.component.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="col-md-3">
+    <ul>
+      <li>Cluster 1</li>
+      <li>Cluster 2</li>
+      <li>Cluster 3</li>
+      <li>Cluster 4</li>
+      <li>Cluster 5</li>
+      <li>Cluster 6</li>
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <dl class="dl-horizontal">
+      <dt>Host Name</dt>
+      <dd>file1.nay.redhat.com</dd>
+      <dt>Device Path</dt>
+      <dd>/dev/disk/pci-0000.05:00-sas-0.2-part1</dd>
+      <dt>Time</dt>
+      <dd>January 15, 2016 10:45:11 AM</dd>
+      <dt>Severity</dt>
+      <dd>Warning</dd>
+      <dt>Cluster</dt>
+      <dd>Cluster 1</dd>
+    </dl>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/app/list-view/examples/clusters-content.component.ts
+++ b/src/app/list-view/examples/clusters-content.component.ts
@@ -1,0 +1,22 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'clusters-content',
+  templateUrl: './clusters-content.component.html'
+})
+export class ClustersContentComponent implements OnInit {
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+}

--- a/src/app/list-view/examples/hosts-content.component.html
+++ b/src/app/list-view/examples/hosts-content.component.html
@@ -1,0 +1,36 @@
+<div class="row">
+  <div class="col-md-3">
+    <ul>
+      <li>Host 1</li>
+      <li>Host 2</li>
+      <li>Host 3</li>
+      <li>Host 4</li>
+      <li>Host 5</li>
+      <li>Host 6</li>
+      <li>Host 7</li>
+      <li>Host 8</li>
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <dl class="dl-horizontal">
+      <dt>Host Name</dt>
+      <dd>file1.nay.redhat.com</dd>
+      <dt>Device Path</dt>
+      <dd>/dev/disk/pci-0000.05:00-sas-0.2-part1</dd>
+      <dt>Time</dt>
+      <dd>January 15, 2016 10:45:11 AM</dd>
+      <dt>Severity</dt>
+      <dd>Warning</dd>
+      <dt>Cluster</dt>
+      <dd>Cluster 1</dd>
+    </dl>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/app/list-view/examples/hosts-content.component.ts
+++ b/src/app/list-view/examples/hosts-content.component.ts
@@ -1,0 +1,22 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'hosts-content',
+  templateUrl: './hosts-content.component.html'
+})
+export class HostsContentComponent implements OnInit {
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+}

--- a/src/app/list-view/examples/images-content.component.html
+++ b/src/app/list-view/examples/images-content.component.html
@@ -1,0 +1,36 @@
+<div class="row">
+  <div class="col-md-3">
+    <ul>
+      <li>Image 1</li>
+      <li>Image 2</li>
+      <li>Image 3</li>
+      <li>Image 4</li>
+      <li>Image 5</li>
+      <li>Image 6</li>
+      <li>Image 7</li>
+      <li>Image 8</li>
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <dl class="dl-horizontal">
+      <dt>Host Name</dt>
+      <dd>file1.nay.redhat.com</dd>
+      <dt>Device Path</dt>
+      <dd>/dev/disk/pci-0000.05:00-sas-0.2-part1</dd>
+      <dt>Time</dt>
+      <dd>January 15, 2016 10:45:11 AM</dd>
+      <dt>Severity</dt>
+      <dd>Warning</dd>
+      <dt>Cluster</dt>
+      <dd>Cluster 1</dd>
+    </dl>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/app/list-view/examples/images-content.component.ts
+++ b/src/app/list-view/examples/images-content.component.ts
@@ -1,0 +1,22 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'images-content',
+  templateUrl: './images-content.component.html'
+})
+export class ImagesContentComponent implements OnInit {
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+}

--- a/src/app/list-view/examples/list-view-basic-example.component.html
+++ b/src/app/list-view/examples/list-view-basic-example.component.html
@@ -1,0 +1,207 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <pfng-list-view
+            [actionTemplate]="actionTemplate"
+            [config]="listViewConfig"
+            [items]="items"
+            [itemTemplate]="itemTemplate"
+            [itemExpandedTemplate]="itemExpandedTemplate"
+            (onActionSelect)="handleAction($event)"
+            (onCheckBoxChange)="handleCheckBoxChange($event)"
+            (onClick)="handleClick($event)"
+            (onDblClick)="handleDblClick($event)"
+            (onDragEnd)="handleDragEnd($event)"
+            (onDragMoved)="handleDragMoved($event)"
+            (onDragStart)="handleDragStart($event)"
+            (onSelect)="handleSelect($event)"
+            (onSelectionChange)="handleSelectionChange($event)">
+          <ng-template #itemTemplate let-item="item" let-index="index">
+            <div *ngIf="index === 0; then showHeader else showCol"></div>
+            <ng-template #showHeader>
+              <div class="list-view-pf-left">
+                <!-- Place holder to match fa-plane icon width below -->
+                <div class="icon-placeholder"></div>
+              </div>
+              <div class="list-view-pf-body">
+                <div class="list-view-pf-description">
+                  <div class="list-group-item-heading">
+                    {{item.name}}
+                  </div>
+                  <div class="list-group-item-text">
+                    {{item.address}}
+                  </div>
+                </div>
+                <div class="list-view-pf-additional-info">
+                  <div class="list-view-pf-additional-info-item">
+                    {{item.additionalInfo}}
+                    <i class="pficon pficon-info padding-left-5" tooltip="Additional info"></i>
+                  </div>
+                </div>
+              </div>
+            </ng-template>
+            <ng-template #showCol>
+              <div class="list-view-pf-left">
+                <span class="fa {{item.typeIcon}} list-view-pf-icon-sm"></span>
+              </div>
+              <div class="list-view-pf-body">
+                <div class="list-view-pf-description">
+                  <div class="list-group-item-heading">
+                    {{item.name}}
+                  </div>
+                  <div class="list-group-item-text">
+                    {{item.address}}
+                  </div>
+                </div>
+                <div class="list-view-pf-additional-info">
+                  <div class="list-view-pf-additional-info-item">
+                    <span class="pficon pficon-screen"></span>
+                    <strong>{{item.hostCount}}</strong> Hosts
+                  </div>
+                  <div class="list-view-pf-additional-info-item">
+                    <span class="pficon pficon-cluster"></span>
+                    <strong>{{item.clusterCount}}</strong> Clusters
+                  </div>
+                  <div class="list-view-pf-additional-info-item">
+                    <span class="pficon pficon-container-node"></span>
+                    <strong>{{item.nodeCount}}</strong> Nodes
+                  </div>
+                  <div class="list-view-pf-additional-info-item">
+                    <span class="pficon pficon-image"></span>
+                    <strong>{{item.imageCount}}</strong> Images
+                  </div>
+                </div>
+              </div>
+            </ng-template>
+          </ng-template>
+          <ng-template #actionTemplate let-item="item" let-index="index">
+            <div *ngIf="index === 0; then showHeader else showCol"></div>
+            <ng-template #showHeader>
+              <span class="margin-left-10">{{item.actions}}</span>
+              <!-- Place holder to match action button width below -->
+              <div class="actions-placeholder"></div>
+            </ng-template>
+            <ng-template #showCol>
+              <pfng-list-view-actions
+                  [config]="getActionsConfig(item, actionButtonTemplate, startButtonTemplate)"
+                  (onActionSelect)="handleAction($event, item)">
+                <ng-template #actionButtonTemplate let-action="action">
+                  <span class="fa fa-plus">&nbsp;</span>{{action.name}}
+                </ng-template>
+                <ng-template #startButtonTemplate let-action="action">
+                  {{item.started === true ? "Starting" : action.name}}
+                </ng-template>
+              </pfng-list-view-actions>
+            </ng-template>
+          </ng-template>
+          <ng-template #itemExpandedTemplate let-item="item" let-index="index">
+            <basic-content [item]="item"></basic-content>
+          </ng-template>
+        </pfng-list-view>
+      </div>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label>Selection</label>
+          <br>
+          <label class="radio-inline">
+            <input id="selectType1" name="selectType" type="radio"
+                   [(ngModel)]="selectType" value="checkbox" (ngModelChange)="updateSelectionType()">Checkbox
+          </label>
+          <label class="radio-inline">
+            <input id="selectType2" name="selectType" type="radio"
+                   [(ngModel)]="selectType" value="row" (ngModelChange)="updateSelectionType()">Row
+          </label>
+          <label class="radio-inline">
+            <input id="selectType3" name="selectType" type="radio"
+                   [(ngModel)]="selectType" value="none" (ngModelChange)="updateSelectionType()">None
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="dblClick" name="dblClick" type="checkbox"
+                   [(ngModel)]="listViewConfig.dblClick"
+                   (ngModelChange)="listViewConfig.multiSelect = false">Double Click
+          </label>
+          <label class="checkbox-inline">
+            <input id="multiSelect" name="multiSelect" type="checkbox"
+                   [(ngModel)]="listViewConfig.multiSelect"
+                   [disabled]="listViewConfig.dblClick">Multi Select
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="showDisabledRows" name="showDisabledRows" type="checkbox"
+                   [(ngModel)]="showDisabledRows"
+                   (ngModelChange)="updateDisabledRows()">Show Disabled Rows
+          </label>
+          <label class="checkbox-inline">
+            <input id="useExpandingRows" name="useExpandingRows" type="checkbox"
+                   [(ngModel)]="listViewConfig.useExpandingRows">Show Simple Expansion
+          </label>
+          <label class="checkbox-inline">
+            <input id="itemsAvailable" name="itemsAvailable" type="checkbox"
+                   [(ngModel)]="itemsAvailable"
+                   (ngModelChange)="updateItemsAvailable()">Items Available
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <!-- Not implemented -- see angular-drag-and-drop-lists
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="dragEnabled" name="dragEnabled" type="checkbox"
+                   [(ngModel)]="listViewConfig.dragEnabled">Drag and Drop
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  -->
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="events-label">Actions: </h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="html">
+        <include-content src="/src/app/list-view/examples/list-view-basic-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="/src/app/list-view/examples/list-view-basic-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/list-view/examples/list-view-basic-example.component.less
+++ b/src/app/list-view/examples/list-view-basic-example.component.less
@@ -1,0 +1,17 @@
+@import (reference) "../../../assets/stylesheets/patternfly-ng";
+
+.actions-placeholder {
+  width: 292px;
+}
+
+.icon-placeholder {
+  width: 30px;
+}
+
+.btn-default.red {
+  color: red;
+}
+
+.dropdown-kebab-pf.red .btn-link {
+  color: red;
+}

--- a/src/app/list-view/examples/list-view-basic-example.component.ts
+++ b/src/app/list-view/examples/list-view-basic-example.component.ts
@@ -1,0 +1,342 @@
+import {
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Action } from '../../models/action';
+import { ActionsConfig } from '../../models/actions-config';
+import { EmptyStateConfig } from '../../empty-state/empty-state-config';
+import { ListViewConfig } from '../list-view-config';
+import { ListViewEvent } from '../list-view-event';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'list-view-basic-example',
+  styleUrls: ['./list-view-basic-example.component.less'],
+  templateUrl: './list-view-basic-example.component.html'
+})
+export class ListViewBasicExampleComponent implements OnInit {
+  actionsConfig: ActionsConfig;
+  actionsText: string = '';
+  allItems: any[];
+  // dragItem: any;
+  emptyStateConfig: EmptyStateConfig;
+  items: any[];
+  itemsAvailable: boolean = true;
+  listViewConfig: ListViewConfig;
+  selectType: string = 'checkbox';
+  showDisabledRows: boolean = false;
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    this.allItems = [{
+      // First array item used for column headings
+      name: 'NAME',
+      actions: 'ACTIONS',
+      additionalInfo: 'ADDITOINAL INFO',
+      address: 'ADDRESS'
+    }, {
+      name: 'Fred Flintstone',
+      address: '20 Dinosaur Way',
+      city: 'Bedrock',
+      state: 'Washingstone',
+      typeIcon: 'fa-plane',
+      clusterCount: 6,
+      hostCount: 8,
+      imageCount: 8,
+      nodeCount: 10
+    }, {
+      name: 'John Smith',
+      address: '415 East Main Street',
+      city: 'Norfolk',
+      state: 'Virginia',
+      typeIcon: 'fa-magic',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8,
+      hideExpandingRowToggle: true
+    }, {
+      name: 'Frank Livingston',
+      address: '234 Elm Street',
+      city: 'Pittsburgh',
+      state: 'Pennsylvania',
+      typeIcon: 'fa-gamepad',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Linda McGovern',
+      address: '22 Oak Street',
+      city: 'Denver',
+      state: 'Colorado',
+      typeIcon: 'fa-linux',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Jim Brown',
+      address: '72 Bourbon Way',
+      city: 'Nashville',
+      state: 'Tennessee',
+      typeIcon: 'fa-briefcase',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Holly Nichols',
+      address: '21 Jump Street',
+      city: 'Hollywood',
+      state: 'California',
+      typeIcon: 'fa-coffee',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Marie Edwards',
+      address: '17 Cross Street',
+      city: 'Boston',
+      state: 'Massachusetts',
+      typeIcon: 'fa-rebel',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Pat Thomas',
+      address: '50 Second Street',
+      city: 'New York',
+      state: 'New York',
+      typeIcon: 'fa-linux',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }];
+    this.items = this.allItems;
+
+    this.actionsConfig = {
+      primaryActions: [{
+        id: 'action1',
+        name: 'Main Action',
+        title: 'Start the server'
+      }],
+      moreActions: [{
+        id: 'action2',
+        name: 'Secondary Action 1',
+        title: 'Do the first thing'
+      }, {
+        id: 'action3',
+        name: 'Secondary Action 2',
+        title: 'Do something else'
+      }, {
+        id: 'action4',
+        name: 'Secondary Action 3',
+        title: 'Do something special'
+      }]
+    } as ActionsConfig;
+
+    this.emptyStateConfig = {
+      actions: this.actionsConfig,
+      icon: 'pficon-warning-triangle-o',
+      title: 'No Items Available',
+      info: 'This is the Empty State component. The goal of a empty state pattern is to provide a good first ' +
+        'impression that helps users to achieve their goals. It should be used when a view is empty because no ' +
+        'objects exists and you want to guide the user to perform specific actions.',
+      helpLink: {
+        label: 'For more information please see the',
+        urlLabel: 'EmptyState example',
+        url: '/emptystate'
+      }
+    } as EmptyStateConfig;
+
+    this.listViewConfig = {
+      dblClick: false,
+      dragEnabled: false,
+      emptyStateConfig: this.emptyStateConfig,
+      headingRow: true,
+      multiSelect: false,
+      selectItems: false,
+      selectionMatchProp: 'name',
+      showSelectBox: true,
+      useExpandingRows: false
+    } as ListViewConfig;
+  }
+
+  ngDoCheck(): void {
+  }
+
+  /**
+   * Get the ActionConfig properties for each row
+   *
+   * @param item The current row item
+   * @param actionButtonTemplate {TemplateRef} Custom button template
+   * @param startButtonTemplate {TemplateRef} Custom button template
+   * @returns {ActionsConfig}
+   */
+  getActionsConfig(item: any, actionButtonTemplate: TemplateRef<any>,
+      startButtonTemplate: TemplateRef<any>): ActionsConfig {
+    let config = {
+      primaryActions: [{
+        id: 'start',
+        name: 'Start',
+        title: 'Start the server',
+        styleClass: 'btn-primary',
+        template: startButtonTemplate
+      }, {
+        id: 'action1',
+        name: 'Action 1',
+        title: 'Perform an action'
+      }, {
+        id: 'action2',
+        name: 'Action 2',
+        title: 'Do something else'
+      }, {
+        id: 'action3',
+        name: 'Action 3',
+        title: 'Do something special',
+        template: actionButtonTemplate
+      }],
+      moreActions: [{
+        id: 'moreActions1',
+        name: 'Action',
+        title: 'Perform an action'
+      }, {
+        id: 'moreActions2',
+        name: 'Another Action',
+        title: 'Do something else'
+      }, {
+        disabled: true,
+        id: 'moreActions3',
+        name: 'Disabled Action',
+        title: 'Unavailable action',
+      }, {
+        id: 'moreActions4',
+        name: 'Something Else',
+        title: ''
+      }, {
+        id: 'moreActions5',
+        name: '',
+        separator: true
+      }, {
+        id: 'moreActions6',
+        name: 'Grouped Action 1',
+        title: 'Do something'
+      }, {
+        id: 'moreActions7',
+        name: 'Grouped Action 2',
+        title: 'Do something similar'
+      }],
+      moreActionsDisabled: false,
+      moreActionsVisible: true
+    } as ActionsConfig;
+
+    // Set button disabled
+    if (item.started === true) {
+      config.primaryActions[0].disabled = true;
+    }
+
+    // Set custom properties for row
+    if (item.name === 'John Smith') {
+      config.moreActionsStyleClass = 'red'; // Set kebab option text red
+      config.primaryActions[1].visible = false; // Hide first button
+      config.primaryActions[2].disabled = true; // Set last button disabled
+      config.primaryActions[3].styleClass = 'red'; // Set last button text red
+      config.moreActions[0].visible = false; // Hide first kebab option
+    }
+
+    // Hide kebab
+    if (item.name === 'Frank Livingston') {
+      config.moreActionsVisible = false;
+    }
+    return config;
+  }
+
+  // Actions
+
+  handleAction($event: Action, item: any): void {
+    if ($event.id === 'start') {
+      item.started = true;
+    }
+    this.actionsText = $event.name + ' selected\r\n' + this.actionsText;
+  }
+
+  handleSelect($event: ListViewEvent): void {
+    this.actionsText = $event.item.name + ' selected\r\n' + this.actionsText;
+  }
+
+  handleSelectionChange($event: ListViewEvent): void {
+    this.actionsText = $event.selectedItems.length + ' items selected\r\n' + this.actionsText;
+  }
+
+  handleClick($event: ListViewEvent): void {
+    this.actionsText = $event.item.name + ' clicked\r\n' + this.actionsText;
+  }
+
+  handleDblClick($event: ListViewEvent): void {
+    this.actionsText = $event.item.name + ' double clicked\r\n' + this.actionsText;
+  }
+
+  handleCheckBoxChange($event: ListViewEvent): void {
+    this.actionsText = $event.item.name + ' checked: ' + $event.item.selected + '\r\n' + this.actionsText;
+  }
+
+/* Not implemented
+  // Drag and drop
+
+  handleDragEnd($event: ListViewEvent): void {
+    this.actionsText = 'drag end\r\n' + this.actionsText;
+  }
+
+  handleDragMoved($event: ListViewEvent): void {
+    let index = -1;
+
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.items[i] === this.dragItem) {
+        index = i;
+        break;
+      }
+    }
+    if (index >= 0) {
+      this.items.splice(index, 1);
+    }
+    this.actionsText = 'drag moved\r\n' + this.actionsText;
+  }
+
+  handleDragStart($event: ListViewEvent): void {
+    this.dragItem = $event.item;
+    this.actionsText = $event.item.name + ': drag start\r\n' + this.actionsText;
+  }
+*/
+
+  // Row selection
+
+  updateDisabledRows(): void {
+    this.items[1].disabled = this.showDisabledRows;
+  }
+
+  updateItemsAvailable(): void {
+    this.items = (this.itemsAvailable) ? this.allItems : [];
+  }
+
+  updateSelectionType(): void {
+    if (this.selectType === 'checkbox') {
+      this.listViewConfig.selectItems = false;
+      this.listViewConfig.showSelectBox = true;
+    } else if (this.selectType === 'row') {
+      this.listViewConfig.selectItems = true;
+      this.listViewConfig.showSelectBox = false;
+    } else {
+      this.listViewConfig.selectItems = false;
+      this.listViewConfig.showSelectBox = false;
+    }
+  }
+}

--- a/src/app/list-view/examples/list-view-compound-example.component.html
+++ b/src/app/list-view/examples/list-view-compound-example.component.html
@@ -1,0 +1,117 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <pfng-list-view
+            [actionTemplate]="actionTemplate"
+            [config]="listViewConfig"
+            [items]="items"
+            [itemTemplate]="itemTemplate"
+            [itemExpandedTemplate]="itemExpandedTemplate"
+            (onActionSelect)="handleAction($event)"
+            (onClick)="handleClick($event)">
+          <ng-template #itemTemplate let-item="item">
+            <div class="list-view-pf-left">
+              <span class="fa {{item.typeIcon}} list-view-pf-icon-sm"></span>
+            </div>
+            <div class="list-view-pf-body">
+              <div class="list-view-pf-description">
+                <div class="list-group-item-heading">
+                  {{item.name}}
+                </div>
+                <div class="list-group-item-text">
+                  {{item.address}}
+                </div>
+              </div>
+              <div class="list-view-pf-additional-info">
+                <div class="list-view-pf-additional-info-item">
+                  <pfng-list-view-compound-toggle [expandingRowId]="'hosts'" [item]="item" [template]="hostsTemplate">
+                    <ng-template #hostsTemplate>
+                      <span class="pficon pficon-screen"></span>
+                      <strong>{{item.hostCount}}</strong> Hosts
+                    </ng-template>
+                  </pfng-list-view-compound-toggle>
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <pfng-list-view-compound-toggle [expandingRowId]="'clusters'" [item]="item" [template]="clustersTemplate">
+                    <ng-template #clustersTemplate>
+                      <span class="pficon pficon-cluster"></span>
+                      <strong>{{item.clustersCount}}</strong> Clusters
+                    </ng-template>
+                  </pfng-list-view-compound-toggle>
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <pfng-list-view-compound-toggle [expandingRowId]="'nodes'" [item]="item" [template]="nodesTemplate">
+                    <ng-template #nodesTemplate>
+                      <span class="pficon pficon-container-node"></span>
+                      <strong>{{item.nodesCount}}</strong> Nodes
+                    </ng-template>
+                  </pfng-list-view-compound-toggle>
+                </div>
+                <div class="list-view-pf-additional-info-item">
+                  <pfng-list-view-compound-toggle [expandingRowId]="'images'" [item]="item" [template]="imagesTemplate">
+                    <ng-template #imagesTemplate>
+                      <span class="pficon pficon-image"></span>
+                      <strong>{{item.imagesCount}}</strong> Images
+                    </ng-template>
+                  </pfng-list-view-compound-toggle>
+                </div>
+              </div>
+            </div>
+          </ng-template>
+          <ng-template #actionTemplate let-item="item" let-index="index">
+            <pfng-list-view-actions
+                [config]="getActionsConfig()"
+                (onActionSelect)="handleAction($event, item)">
+            </pfng-list-view-actions>
+          </ng-template>
+          <ng-template #itemExpandedTemplate let-item="item" let-index="index">
+            <basic-content [item]="item" *ngIf="item.expandingRowId === undefined"></basic-content>
+            <clusters-content *ngIf="item.expandingRowId === 'clusters'"></clusters-content>
+            <hosts-content *ngIf="item.expandingRowId === 'hosts'"></hosts-content>
+            <images-content *ngIf="item.expandingRowId === 'images'"></images-content>
+            <nodes-content *ngIf="item.expandingRowId === 'nodes'"></nodes-content>
+          </ng-template>
+        </pfng-list-view>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="useExpandingRows" name="useExpandingRows" type="checkbox"
+                   [(ngModel)]="listViewConfig.useExpandingRows">Show Simple Expansion
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="events-label">Actions: </h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="html">
+        <include-content src="/src/app/list-view/examples/list-view-compound-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="/src/app/list-view/examples/list-view-compound-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/list-view/examples/list-view-compound-example.component.ts
+++ b/src/app/list-view/examples/list-view-compound-example.component.ts
@@ -1,0 +1,185 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Action } from '../../models/action';
+import { ActionsConfig } from '../../models/actions-config';
+import { ListViewConfig } from '../list-view-config';
+import { ListViewEvent } from '../list-view-event';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'list-view-compound-example',
+  templateUrl: './list-view-compound-example.component.html'
+})
+export class ListViewCompoundExampleComponent implements OnInit {
+  actionsText: string = '';
+  allItems: any[];
+  items: any[];
+  listViewConfig: ListViewConfig;
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    this.allItems = [{
+      name: 'Fred Flintstone',
+      address: '20 Dinosaur Way',
+      city: 'Bedrock',
+      state: 'Washingstone',
+      typeIcon: 'fa-plane',
+      clusterCount: 6,
+      hostCount: 8,
+      imageCount: 8,
+      nodeCount: 10
+    }, {
+      name: 'John Smith',
+      address: '415 East Main Street',
+      city: 'Norfolk',
+      state: 'Virginia',
+      typeIcon: 'fa-magic',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8,
+      hideExpandingRowToggle: true
+    }, {
+      name: 'Frank Livingston',
+      address: '234 Elm Street',
+      city: 'Pittsburgh',
+      state: 'Pennsylvania',
+      typeIcon: 'fa-gamepad',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Linda McGovern',
+      address: '22 Oak Street',
+      city: 'Denver',
+      state: 'Colorado',
+      typeIcon: 'fa-linux',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Jim Brown',
+      address: '72 Bourbon Way',
+      city: 'Nashville',
+      state: 'Tennessee',
+      typeIcon: 'fa-briefcase',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Holly Nichols',
+      address: '21 Jump Street',
+      city: 'Hollywood',
+      state: 'California',
+      typeIcon: 'fa-coffee',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Marie Edwards',
+      address: '17 Cross Street',
+      city: 'Boston',
+      state: 'Massachusetts',
+      typeIcon: 'fa-rebel',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }, {
+      name: 'Pat Thomas',
+      address: '50 Second Street',
+      city: 'New York',
+      state: 'New York',
+      typeIcon: 'fa-linux',
+      hostCount: 8,
+      clusterCount: 6,
+      nodeCount: 10,
+      imageCount: 8
+    }];
+    this.items = this.allItems;
+
+    this.listViewConfig = {
+      dblClick: false,
+      dragEnabled: false,
+      headingRow: false,
+      multiSelect: false,
+      selectItems: false,
+      selectionMatchProp: 'name',
+      showSelectBox: false,
+      useExpandingRows: false
+    } as ListViewConfig;
+  }
+
+  ngDoCheck(): void {
+  }
+
+  /**
+   * Get the ActionConfig properties for each row
+   *
+   * @returns {ActionsConfig}
+   */
+  getActionsConfig(): ActionsConfig {
+    let config = {
+      primaryActions: [{
+        id: 'action1',
+        name: 'Action 1',
+        title: 'Perform an action'
+      }],
+      moreActions: [{
+        id: 'moreActions1',
+        name: 'Action',
+        title: 'Perform an action'
+      }, {
+        id: 'moreActions2',
+        name: 'Another Action',
+        title: 'Do something else'
+      }, {
+        disabled: true,
+        id: 'moreActions3',
+        name: 'Disabled Action',
+        title: 'Unavailable action',
+      }, {
+        id: 'moreActions4',
+        name: 'Something Else',
+        title: ''
+      }, {
+        id: 'moreActions5',
+        name: '',
+        separator: true
+      }, {
+        id: 'moreActions6',
+        name: 'Grouped Action 1',
+        title: 'Do something'
+      }, {
+        id: 'moreActions7',
+        name: 'Grouped Action 2',
+        title: 'Do something similar'
+      }],
+    } as ActionsConfig;
+
+    return config;
+  }
+
+  // Actions
+
+  handleAction($event: Action, item: any): void {
+    if ($event.name === 'Start') {
+      item.started = true;
+    }
+    this.actionsText = $event.name + ' selected\r\n' + this.actionsText;
+  }
+
+  handleClick($event: ListViewEvent): void {
+    this.actionsText = $event.item.name + ' clicked\r\n' + this.actionsText;
+  }
+}

--- a/src/app/list-view/examples/list-view-example.component.html
+++ b/src/app/list-view/examples/list-view-example.component.html
@@ -1,0 +1,16 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-xs-12">
+      <h4>List View Component Example</h4>
+      <hr/>
+    </div>
+  </div>
+  <tabset>
+    <tab heading="Basic" (select)="tabSelected($event)">
+      <list-view-basic-example *ngIf="activeTab === 'Basic' || activeTab === ''"></list-view-basic-example>
+    </tab>
+    <tab heading="Compound Expansion" (select)="tabSelected($event)">
+      <list-view-compound-example *ngIf="activeTab === 'Compound Expansion'"></list-view-compound-example>
+    </tab>
+  </tabset>
+</div>

--- a/src/app/list-view/examples/list-view-example.component.ts
+++ b/src/app/list-view/examples/list-view-example.component.ts
@@ -1,0 +1,31 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { TabDirective } from 'ngx-bootstrap/tabs';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'list-view-example',
+  templateUrl: './list-view-example.component.html'
+})
+export class ListViewExampleComponent implements OnInit {
+  activeTab: string = '';
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+
+  // Actions
+
+  tabSelected($event: TabDirective): void {
+    this.activeTab = $event.heading;
+  }
+}

--- a/src/app/list-view/examples/list-view-example.module.ts
+++ b/src/app/list-view/examples/list-view-example.module.ts
@@ -1,0 +1,44 @@
+import { NgModule }  from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+
+import { BasicContentComponent } from './basic-content.component';
+import { ClustersContentComponent } from './clusters-content.component';
+import { DemoComponentsModule } from '../../../demo/components/demo-components.module';
+import { HostsContentComponent } from './hosts-content.component';
+import { ImagesContentComponent } from './images-content.component';
+import { ListViewModule } from '../list-view.module';
+import { ListViewBasicExampleComponent } from './list-view-basic-example.component';
+import { ListViewCompoundExampleComponent } from './list-view-compound-example.component';
+import { ListViewExampleComponent } from './list-view-example.component';
+import { NodesContentComponent } from './nodes-content.component';
+
+@NgModule({
+  declarations: [
+    BasicContentComponent,
+    ClustersContentComponent,
+    HostsContentComponent,
+    ImagesContentComponent,
+    ListViewBasicExampleComponent,
+    ListViewCompoundExampleComponent,
+    ListViewExampleComponent,
+    NodesContentComponent
+  ],
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    DemoComponentsModule,
+    FormsModule,
+    ListViewModule,
+    TabsModule.forRoot(),
+    TooltipModule.forRoot()
+  ],
+  providers: [ BsDropdownConfig, TabsetConfig, TooltipConfig ]
+})
+export class ListViewExampleModule {
+  constructor() {}
+}

--- a/src/app/list-view/examples/nodes-content.component.html
+++ b/src/app/list-view/examples/nodes-content.component.html
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="col-md-3">
+    <ul>
+      <li>Node 1</li>
+      <li>Node 2</li>
+      <li>Node 3</li>
+      <li>Node 4</li>
+      <li>Node 5</li>
+      <li>Node 6</li>
+      <li>Node 7</li>
+      <li>Node 8</li>
+      <li>Node 9</li>
+      <li>Node 10</li>
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <dl class="dl-horizontal">
+      <dt>Host Name</dt>
+      <dd>file1.nay.redhat.com</dd>
+      <dt>Device Path</dt>
+      <dd>/dev/disk/pci-0000.05:00-sas-0.2-part1</dd>
+      <dt>Time</dt>
+      <dd>January 15, 2016 10:45:11 AM</dd>
+      <dt>Severity</dt>
+      <dd>Warning</dd>
+      <dt>Cluster</dt>
+      <dd>Cluster 1</dd>
+    </dl>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/app/list-view/examples/nodes-content.component.ts
+++ b/src/app/list-view/examples/nodes-content.component.ts
@@ -1,0 +1,22 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'nodes-content',
+  templateUrl: './nodes-content.component.html'
+})
+export class NodesContentComponent implements OnInit {
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngDoCheck(): void {
+  }
+}

--- a/src/app/list-view/list-view-actions.component.html
+++ b/src/app/list-view/list-view-actions.component.html
@@ -1,0 +1,37 @@
+<span *ngIf="config.primaryActions?.length > 0">
+  <button *ngFor="let action of config.primaryActions"
+          class="btn btn-default primary-action {{action.styleClass}}" title="{{action.title}}" type="button"
+          [ngClass]="{'invisible': action.visible === false}"
+          (click)="handleAction(action)"
+          [disabled]="action.disabled">
+    <div *ngIf="action.template; then showButtonTemplate else showButtonName"></div>
+    <ng-template #showButtonTemplate let-action="action" let-item="item"
+                 [ngTemplateOutlet]="action.template"
+                 [ngOutletContext]="{ action: action, item: item }"></ng-template>
+    <ng-template #showButtonName>
+      {{action.name}}
+    </ng-template>
+  </button>
+</span>
+<span class="dropdown dropdown-kebab-pf pull-right {{config.moreActionsStyleClass}}" dropdown
+      [ngClass]="{'dropdown': !isMoreActionsDropup, 'dropup': isMoreActionsDropup, 'invisible': config.moreActionsVisible === false}"
+      *ngIf="config.moreActions?.length > 0">
+  <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle
+          [ngClass]="{'disabled': config.moreActionsDisabled}"
+          (click)="initMoreActionsDropup($event)">
+    <span class="fa fa-ellipsis-v"></span>
+  </button>
+  <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
+    <li *ngFor="let action of config.moreActions"
+        [attr.role]="action.separator === true ? 'separator' : 'menuitem'"
+        [ngClass]="{'divider': action.separator === true, 'disabled': action.disabled === true, 'hidden': action.visible === false}">
+      <a *ngIf="action.separator !== true"
+         class="dropdown-item secondary-action"
+         href="javascript:void(0)"
+         title="{{action.title}}"
+         (click)="handleAction(action)">
+        {{action.name}}
+      </a>
+    </li>
+  </ul>
+</span>

--- a/src/app/list-view/list-view-actions.component.less
+++ b/src/app/list-view/list-view-actions.component.less
@@ -1,0 +1,1 @@
+@import (reference) "../../assets/stylesheets/patternfly-ng";

--- a/src/app/list-view/list-view-actions.component.ts
+++ b/src/app/list-view/list-view-actions.component.ts
@@ -1,0 +1,123 @@
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Action } from '../models/action';
+import { ActionsConfig } from '../models/actions-config';
+
+import { cloneDeep, defaults, isEqual } from 'lodash';
+
+/**
+ * List view actions component.
+ *
+ * config - The ActionsConfig object containing action properties
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-list-view-actions',
+  styleUrls: ['./list-view-actions.component.less'],
+  templateUrl: './list-view-actions.component.html'
+})
+export class ListViewActionsComponent implements OnInit {
+  @Input() config: ActionsConfig;
+
+  @Output('onActionSelect') onActionSelect = new EventEmitter();
+
+  defaultConfig = {
+    moreActionsDisabled: false,
+    moreActionsVisible: true
+  } as ActionsConfig;
+  isMoreActionsDropup: boolean = false;
+  prevConfig: ActionsConfig;
+
+  constructor(private el: ElementRef) {
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    this.setupConfig();
+  }
+
+  ngDoCheck(): void {
+    // Do a deep compare on config
+    if (!isEqual(this.config, this.prevConfig)) {
+      this.setupConfig();
+    }
+  }
+
+  setupConfig(): void {
+    if (this.config !== undefined) {
+      defaults(this.config, this.defaultConfig);
+    } else {
+      this.config = cloneDeep(this.defaultConfig);
+    }
+  }
+
+  // Actions
+
+  handleAction(action: Action): void {
+    if (action && action.disabled !== true) {
+      this.onActionSelect.emit(action);
+    }
+  }
+
+  /**
+   * Set flag indicating if kebab should be shown as a dropdown or dropup
+   *
+   * @param $event The MouseEvent triggering this function
+   */
+  initMoreActionsDropup($event: MouseEvent): void {
+    window.requestAnimationFrame(() => {
+      let kebabContainer = this.closest($event.target, '.dropdown-kebab-pf.open', 'pfng-list-view-actions');
+      let listViewContainer = this.closest(this.el.nativeElement, '.list-group.list-view-pf', 'pfng-list-view');
+      if (kebabContainer === null || listViewContainer === null) {
+        return;
+      }
+
+      let dropdownButton = kebabContainer.querySelector('.dropdown-toggle');
+      let dropdownMenu =  kebabContainer.querySelector('.dropdown-menu');
+      let buttonRect = dropdownButton.getBoundingClientRect();
+      let menuRect = dropdownMenu.getBoundingClientRect();
+      let menuTop = buttonRect.top - menuRect.height;
+      let menuBottom = buttonRect.top + buttonRect.height + menuRect.height;
+      let parentRect = listViewContainer.getBoundingClientRect();
+
+      if ((menuBottom <= parentRect.top + parentRect.height) || (menuTop < parentRect.top)) {
+        this.isMoreActionsDropup = false;
+      } else {
+        this.isMoreActionsDropup = true;
+      }
+    });
+  }
+
+  // Private
+
+  /**
+   * Get the closest ancestor based on given selector
+   *
+   * @param el The HTML element to start searching for matching ancestor
+   * @param selector The selector to match
+   * @param stopSelector If this selector is matched, the search is stopped
+   * @returns {HTMLElement} The matching HTML element or null if not found
+   */
+  private closest(el: any, selector: string, stopSelector: string): HTMLElement {
+    let retval = null;
+    while (el) {
+      if (el.matches(selector)) {
+        retval = el;
+        break;
+      } else if (stopSelector && el.matches(stopSelector)) {
+        break;
+      }
+      el = el.parentElement;
+    }
+    return retval;
+  }
+}

--- a/src/app/list-view/list-view-compound-toggle.component.html
+++ b/src/app/list-view/list-view-compound-toggle.component.html
@@ -1,0 +1,6 @@
+<div class="list-view-pf-expand" (click)="toggleExpandingRow(item, 'hosts')">
+  <span class="fa fa-angle-right" [ngClass]="{'fa-angle-down': isRowExpanded()}"></span>
+  <ng-template *ngIf="template" let-item="item"
+               [ngTemplateOutlet]="template"
+               [ngOutletContext]="{ item: item }"></ng-template>
+</div>

--- a/src/app/list-view/list-view-compound-toggle.component.ts
+++ b/src/app/list-view/list-view-compound-toggle.component.ts
@@ -1,0 +1,59 @@
+import {
+  Component,
+  Input,
+  OnInit,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
+
+/**
+ * List view component.
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-list-view-compound-toggle',
+  templateUrl: './list-view-compound-toggle.component.html'
+})
+export class ListViewCompoundToggleComponent implements OnInit {
+  @Input() expandingRowId: string;
+  @Input() item: any;
+  @Input() template: TemplateRef<any>;
+
+  constructor() {
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    if (this.item === undefined) {
+      throw new Error('ListViewCompoundToggleComponent: item attribute not set');
+    }
+    if (this.expandingRowId === undefined) {
+      throw new Error('ListViewCompoundToggleComponent: expandingRowId attribute not set');
+    }
+  }
+
+  // Actions
+
+  /**
+   * Test if row is expanded based on given expanding row ID
+   *
+   * @returns {boolean} True if row is expanded
+   */
+  isRowExpanded(): boolean {
+    return (this.item.isRowExpanded === true && this.item.expandingRowId === this.expandingRowId);
+  }
+
+  /**
+   * Toggle expanding row open/close
+   */
+  toggleExpandingRow(): void {
+    // Row may already be open
+    if (this.item.isRowExpanded && this.item.expandingRowId !== this.expandingRowId) {
+      this.item.expandingRowId = this.expandingRowId;
+      return;
+    }
+    this.item.expandingRowId = this.expandingRowId;
+    this.item.isRowExpanded = !this.item.isRowExpanded;
+  }
+}

--- a/src/app/list-view/list-view-config.ts
+++ b/src/app/list-view/list-view-config.ts
@@ -1,0 +1,28 @@
+import { EmptyStateConfig } from '../empty-state/empty-state-config';
+
+/*
+ * A list view config containing:
+ *
+ * dlbClick - Handle double clicking (item remains selected on a double click). Default is false
+ * dragEnabled - Enable drag and drop. Default is false
+ * emptyStateConfig - Empty state config for when no items are available
+ * headingRow - Show list heading. First row shall be used to define heading text.
+ * multiSelect - Allow multiple row selections, selectItems must also be set, not applicable when dblClick is true. Default is false
+ * selectedItems - Current set of selected items
+ * selectItems - Allow row selection, default is false
+ * selectionMatchProp - Property of the items to use for determining matching, default is 'uuid'
+ * showSelectBox - Show item selection boxes for each item, default is true
+ * useExpandingRows - Allow row expansion for each list item
+ */
+export class ListViewConfig {
+  dblClick?: boolean;
+  dragEnabled?: boolean;
+  emptyStateConfig?: EmptyStateConfig;
+  headingRow?: boolean;
+  multiSelect?: boolean;
+  selectedItems?: any[];
+  selectItems?: boolean;
+  selectionMatchProp?: string;
+  showSelectBox?: boolean;
+  useExpandingRows?: boolean;
+}

--- a/src/app/list-view/list-view-event.ts
+++ b/src/app/list-view/list-view-event.ts
@@ -1,0 +1,14 @@
+import { Action } from '../models/action';
+
+/*
+ * A list view evet containing:
+ *
+ * action - Configuration settings for given action
+ * item - The item associated with the list view row
+ * selectedItems - The currently selected items, if applicable
+ */
+export class ListViewEvent {
+  action?: Action;
+  item?: any;
+  selectedItems?: any[];
+}

--- a/src/app/list-view/list-view.component.html
+++ b/src/app/list-view/list-view.component.html
@@ -1,0 +1,76 @@
+<span>
+  <div class="list-group list-view-pf list-view-pf-view" dnd-list="items"
+       [ngClass]="{'list-view-pf-dnd': config.dragEnabled}"
+       *ngIf="!itemsEmpty">
+    <div class='dndPlaceholder'></div>
+    <div class="list-group-item {{item?.rowClass}}"
+         *ngFor="let item of items; let i = index"
+         dnd-draggable="item"
+         dnd-effect-allowed="move"
+         dnd-disable-if="!config.dragEnabled"
+         dnd-dragstart="dragStart(item)"
+         dnd-moved="dragMoved(item)"
+         dnd-dragend="dragEnd(item)"
+         [ngClass]="{'drag-original': isDragOriginal(item),
+                     'pf-selectable': selectItems,
+                     'active': isSelected(item),
+                     'disabled': item.disabled,
+                     'list-view-pf-expand-active': item.isRowExpanded,
+                     'pfng-list-view-heading-row': config.headingRow && i === 0}">
+      <div class="list-group-item-header">
+        <div class="list-view-pf-dnd-drag-items" *ngIf="config.dragEnabled">
+          <div class="list-view-pf-main-info"></div>
+        </div>
+        <div class="pfng-list-view-dnd-drag-container"
+             [ngClass]="{'list-view-pf-dnd-original-items': config.dragEnabled}">
+          <div *ngIf="(config.headingRow && i === 0); then showExpRowHeader else showExpRow"></div>
+          <ng-template #showExpRowHeader>
+            <div class="pfng-expand-placeholder" *ngIf="config.useExpandingRows"></div>
+          </ng-template>
+          <ng-template #showExpRow>
+            <div class="list-view-pf-expand" *ngIf="config.useExpandingRows">
+              <span class="fa fa-angle-right"
+                    *ngIf="item.hideExpandingRowToggle !== true"
+                    (click)="toggleExpandingRow(item)"
+                    [ngClass]="{'fa-angle-down': item.isRowExpanded && item.expandingRowId === undefined}"></span>
+              <div class="pfng-expand-placeholder" *ngIf="item.hideExpandingRowToggle === true"></div>
+            </div>
+          </ng-template>
+          <div *ngIf="(config.headingRow && i === 0); then showCbHeader else showCb"
+               [ngClass]="{'pfng-list-view-heading': config.headingRow && i === 0}"></div>
+          <ng-template #showCbHeader>
+            <div class="pfng-cb-placeholder" *ngIf="config.showSelectBox"></div>
+          </ng-template>
+          <ng-template #showCb>
+            <div class="list-view-pf-checkbox" *ngIf="config.showSelectBox">
+              <input type="checkbox" value="item.selected"
+                     [(ngModel)]="item.selected"
+                     [disabled]="item.disabled"
+                     (ngModelChange)="checkBoxChange(item)">
+            </div>
+          </ng-template>
+          <div class="list-view-pf-actions" *ngIf="actionTemplate"
+               [ngClass]="{'pfng-list-view-heading': config.headingRow && i === 0}">
+            <ng-template [ngTemplateOutlet]="actionTemplate" [ngOutletContext]="{ item: item, index: i }"></ng-template>
+          </div>
+          <div class="list-view-pf-main-info"
+               (click)="itemClick($event, item)"
+               (dblclick)="dblClick($event, item)"
+               [ngClass]="{'pfng-list-view-heading': config.headingRow && i === 0}">
+            <ng-template [ngTemplateOutlet]="itemTemplate" [ngOutletContext]="{ item: item, index: i }"></ng-template>
+          </div>
+        </div>
+        <div class="list-group-item-container container-fluid"
+             *ngIf="!(config.headingRow && i === 0) && itemExpandedTemplate && item.isRowExpanded">
+          <div class="close">
+            <span class="pficon pficon-close" (click)="closeExpandingRow(item)"></span>
+          </div>
+          <ng-template [ngTemplateOutlet]="itemExpandedTemplate"
+                       [ngOutletContext]="{ item: item, index: i }"></ng-template>
+        </div>
+      </div>
+    </div>
+  </div>
+  <pfng-empty-state *ngIf="itemsEmpty" [config]="config.emptyStateConfig"
+                    (onActionSelect)="handleAction($event)"></pfng-empty-state>
+</span>

--- a/src/app/list-view/list-view.component.less
+++ b/src/app/list-view/list-view.component.less
@@ -1,0 +1,39 @@
+@import (reference) "../../assets/stylesheets/patternfly-ng";
+
+/* Ensure min button width (fabric8-ui fix) */
+.list-view-pf-actions {
+  .dropdown-kebab-pf {
+    .btn { min-width: initial; }
+  }
+}
+
+/* Why does PF add margin-top? */
+.list-view-pf-view {
+  margin-top: 0; // was 30
+}
+
+.pfng-list-view-dnd-drag-container { display: flex; }
+
+.pfng-expand-placeholder { width: 15px; }
+.pfng-cb-placeholder { width: 38px; }
+
+.pfng-list-view-heading {
+  @media (max-width: 992px) { display: none; }
+  .list-group-item-heading {
+    font-size: @font-size-base;
+    font-weight: initial;
+  }
+}
+
+.list-view-pf .list-group-item {
+  &.pfng-list-view-heading-row {
+    border-top: none;
+    pointer-events: none;
+    &:hover {
+      background-color: @color-pf-white;
+    }
+    i {
+      pointer-events: auto;
+    }
+  }
+}

--- a/src/app/list-view/list-view.component.spec.ts
+++ b/src/app/list-view/list-view.component.spec.ts
@@ -1,0 +1,326 @@
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule }  from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { ActionsConfig } from '../models/actions-config';
+import { EmptyStateConfig } from '../empty-state/empty-state-config';
+import { EmptyStateModule } from '../empty-state/empty-state.module';
+import { ListViewComponent } from './list-view.component';
+import { ListViewConfig } from './list-view-config';
+
+describe('List View component - ', () => {
+  let comp: ListViewComponent;
+  let fixture: ComponentFixture<ListViewComponent>;
+
+  let actionsConfig: ActionsConfig;
+  let config: ListViewConfig;
+  let emptyStateConfig: EmptyStateConfig;
+  let items: any[];
+
+  beforeEach(() => {
+    items = [{
+      name: 'Fred Flintstone',
+      address: '20 Dinosaur Way',
+      city: 'Bedrock',
+      state: 'Washingstone'
+    }, {
+      name: 'John Smith',
+      address: '415 East Main Street',
+      city: 'Norfolk',
+      state: 'Virginia',
+      rowExpansionDisabled: true
+    }, {
+      name: 'Frank Livingston',
+      address: '234 Elm Street',
+      city: 'Pittsburgh',
+      state: 'Pennsylvania'
+    }, {
+      name: 'Linda McGovern',
+      address: '22 Oak Street',
+      city: 'Denver',
+      state: 'Colorado'
+    }, {
+      name: 'Jim Brown',
+      address: '72 Bourbon Way',
+      city: 'Nashville',
+      state: 'Tennessee'
+    }, {
+      name: 'Holly Nichols',
+      address: '21 Jump Street',
+      city: 'Hollywood',
+      state: 'California'
+    }, {
+      name: 'Marie Edwards',
+      address: '17 Cross Street',
+      city: 'Boston',
+      state: 'Massachusetts'
+    }, {
+      name: 'Pat Thomas',
+      address: '50 Second Street',
+      city: 'New York',
+      state: 'New York'
+    }];
+
+    actionsConfig = {
+      primaryActions: [{
+        id: 'action1',
+        name: 'Main Action',
+        title: 'Start the server'
+      }],
+      moreActions: [{
+        id: 'action2',
+        name: 'Secondary Action 1',
+        title: 'Do the first thing'
+      }, {
+        id: 'action3',
+        name: 'Secondary Action 2',
+        title: 'Do something else'
+      }, {
+        id: 'action4',
+        name: 'Secondary Action 3',
+        title: 'Do something special'
+      }]
+    } as ActionsConfig;
+
+    emptyStateConfig = {
+      actions: actionsConfig,
+      icon: 'pficon-warning-triangle-o',
+      title: 'No Items Available',
+      info: 'This is the Empty State component. The goal of a empty state pattern is to provide a good first ' +
+        'impression that helps users to achieve their goals. It should be used when a view is empty because no ' +
+        'objects exists and you want to guide the user to perform specific actions.',
+      helpLink: {
+        label: 'For more information please see the',
+        urlLabel: 'EmptyState example',
+        url: '/emptystate'
+      }
+    } as EmptyStateConfig;
+
+    config = {
+      dblClick: false,
+      dragEnabled: false,
+      emptyStateConfig: emptyStateConfig,
+      multiSelect: false,
+      selectItems: false,
+      selectionMatchProp: 'name',
+      showSelectBox: true,
+      useExpandingRows: false
+    } as ListViewConfig;
+  });
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule, EmptyStateModule, FormsModule],
+      declarations: [ListViewComponent],
+      providers: []
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(ListViewComponent);
+        comp = fixture.componentInstance;
+        comp.config = config;
+        comp.items = items;
+        fixture.detectChanges();
+      });
+  }));
+
+  it('should have correct number of rows', () => {
+    let elements = fixture.debugElement.queryAll(By.css('.list-group-item'));
+    expect(elements.length).toBe(8);
+  });
+
+  it('should show the select checkbox by default', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
+    let checkItems = fixture.debugElement.queryAll(By.css('.list-view-pf-checkbox'));
+
+    expect(checkItems.length).toBe(items.length);
+
+    // allow item selection
+    config.selectItems = false;
+    fixture.detectChanges();
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(0);
+  });
+
+  it('should not show the select checkboxes when showSelectBox is false', function () {
+    let checkItems = fixture.debugElement.queryAll(By.css('.list-view-pf-checkbox'));
+
+    expect(checkItems.length).toBe(items.length);
+
+    // disallow checkbox selection
+    config.showSelectBox = false;
+    fixture.detectChanges();
+
+    checkItems = fixture.debugElement.queryAll(By.css('.list-view-pf-checkbox'));
+    expect(checkItems.length).toBe(0);
+  });
+
+  it('should not allow selection when selectItems is false', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+
+    expect(selectedItems.length).toBe(0);
+
+    // allow item selection
+    config.selectItems = false;
+    fixture.detectChanges();
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(0);
+  });
+
+  it('should add selected class to clicked list item', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-view-pf-main-info'));
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+
+    expect(selectedItems.length).toBe(0);
+
+    // allow item selection
+    config.selectItems = true;
+    config.showSelectBox = false;
+    fixture.detectChanges();
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(1);
+  });
+
+  it('should manage selected array', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-view-pf-main-info'));
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+
+    expect(config.selectedItems.length).toBe(0);
+
+    // allow item selection
+    config.selectItems = true;
+    config.showSelectBox = false;
+    fixture.detectChanges();
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(1);
+    expect(config.selectedItems.length).toBe(1);
+  });
+
+  it('should handle double click event', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-view-pf-main-info'));
+    let doubleClickWorking = false;
+
+    comp.dblClick = ($event) => {
+      doubleClickWorking = true;
+    };
+    fixture.detectChanges();
+
+    expect(doubleClickWorking).toBe(false);
+
+    listItems[1].triggerEventHandler('dblclick', {});
+    expect(doubleClickWorking).toBe(true);
+  });
+
+  it('should respect the multiSelect setting', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-view-pf-main-info'));
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+
+    expect(selectedItems.length).toBe(0);
+
+    // allow item selection
+    config.selectItems = true;
+    config.showSelectBox = false;
+    config.multiSelect = false;
+    fixture.detectChanges();
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(1);
+
+    listItems[2].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(1);
+
+    config.multiSelect = true;
+    fixture.detectChanges();
+
+    listItems[3].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(2);
+  });
+
+  it('should set disabled rows correctly', function () {
+    let listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
+
+    // allow item selection
+    config.selectItems = true;
+    config.showSelectBox = false;
+    comp.items[2].disabled = true;
+    fixture.detectChanges();
+
+    let disabledItems = fixture.debugElement.queryAll(By.css('.list-group-item.disabled'));
+    expect(disabledItems.length).toBe(1);
+
+    listItems[1].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    let selectedItems = fixture.debugElement.queryAll(By.css('.active'));
+    expect(selectedItems.length).toBe(0);
+  });
+
+  it('should not allow both row and checkbox selection', function () {
+    let exceptionRaised = false;
+    let badConfig = {
+      selectItems: true,
+      showSelectBox: true
+    };
+
+    try {
+      comp.config = badConfig;
+      fixture.detectChanges();
+    } catch (e) {
+      exceptionRaised = true;
+    }
+    expect(exceptionRaised).toBe(true);
+  });
+
+  it('should allow expanding rows', function () {
+    config.useExpandingRows = true;
+    fixture.detectChanges();
+
+    let listItems = fixture.debugElement.queryAll(By.css('.list-view-pf-expand .fa-angle-right'));
+    expect(items.length).toBe(8);
+
+    listItems[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    let openItem = fixture.debugElement.queryAll(By.css('.list-view-pf-expand .fa-angle-right.fa-angle-down'));
+    expect(openItem.length).toBe(1);
+  });
+
+  it('should show the empty state when specified', function () {
+    comp.items = [];
+    fixture.detectChanges();
+
+    let title = fixture.debugElement.query(By.css('#title'));
+    expect(title.nativeElement.textContent.trim().slice(0, 'No Items Available'.length)).toBe('No Items Available');
+  });
+});

--- a/src/app/list-view/list-view.component.ts
+++ b/src/app/list-view/list-view.component.ts
@@ -1,0 +1,229 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Action } from '../models/action';
+import { ListViewConfig } from './list-view-config';
+import { ListViewEvent } from './list-view-event';
+
+import { cloneDeep, defaults, isEqual, without } from 'lodash';
+
+/**
+ * List view component.
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-list-view',
+  styleUrls: ['./list-view.component.less'],
+  templateUrl: './list-view.component.html'
+})
+export class ListViewComponent implements OnInit {
+  @Input() actionTemplate: TemplateRef<any>;
+  @Input() config: ListViewConfig;
+  @Input() itemExpandedTemplate: TemplateRef<any>;
+  @Input() items: any[];
+  @Input() itemTemplate: TemplateRef<any>;
+
+  @Output('onActionSelect') onActionSelect = new EventEmitter();
+  @Output('onCheckBoxChange') onCheckBoxChange = new EventEmitter();
+  @Output('onClick') onClick = new EventEmitter();
+  @Output('onDblClick') onDblClick = new EventEmitter();
+  @Output('onDragEnd') onDragEnd = new EventEmitter();
+  @Output('onDragMoved') onDragMoved = new EventEmitter();
+  @Output('onDragStart') onDragStart = new EventEmitter();
+  @Output('onSelect') onSelect = new EventEmitter();
+  @Output('onSelectionChange') onSelectionChange = new EventEmitter();
+
+  dragItem: any;
+  itemsEmpty: boolean = true;
+  prevConfig: ListViewConfig;
+
+  defaultConfig = {
+    selectItems: false,
+    multiSelect: false,
+    dblClick: false,
+    dragEnabled: false,
+    selectedItems: [],
+    selectionMatchProp: 'uuid',
+    checkDisabled: false,
+    useExpandingRows: false,
+    showSelectBox: true
+  } as ListViewConfig;
+
+  constructor() {
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    this.setupConfig();
+  }
+
+  ngDoCheck(): void {
+    // Do a deep compare on config
+    if (!isEqual(this.config, this.prevConfig)) {
+      this.setupConfig();
+    }
+    this.itemsEmpty = !(this.items !== undefined && this.items.length > 0);
+  }
+
+  setupConfig(): void {
+    if (this.config !== undefined) {
+      defaults(this.config, this.defaultConfig);
+    } else {
+      this.config = cloneDeep(this.defaultConfig);
+    }
+    if ((this.config.multiSelect === undefined || this.config.multiSelect === false)
+        && this.config.selectedItems && this.config.selectedItems.length > 0) {
+      this.config.selectedItems = [this.config.selectedItems[0]];
+    }
+    if (this.config.selectItems && this.config.showSelectBox) {
+      throw new Error('ListViewComponent - Illegal use: ' +
+        'Cannot use both select box and click selection at the same time.');
+    }
+    this.prevConfig = cloneDeep(this.config);
+  }
+
+  // Actions
+
+  handleAction(action: Action): void {
+    if (action && action.disabled !== true) {
+      this.onActionSelect.emit(action);
+    }
+  }
+
+  // Checkbox
+
+  checkBoxChange(item: any): void {
+    this.onCheckBoxChange.emit({
+      item: item
+    } as ListViewEvent);
+  }
+
+  isSelected(item: any): boolean {
+    let matchProp = this.config.selectionMatchProp;
+    let selected = false;
+
+    if (this.config.showSelectBox) {
+      selected = item.selected;
+    } else if (this.config.selectItems !== undefined) {
+      this.config.selectedItems.forEach((itemObj) => {
+        if (itemObj[matchProp] === item[matchProp]) {
+          selected = true;
+        }
+      });
+    }
+    return selected;
+  }
+
+  // Drag and drop
+
+  dragEnd(): void {
+    this.onDragEnd.emit({
+      item: this.dragItem
+    } as ListViewEvent);
+  }
+
+  dragMoved(): void {
+    this.onDragMoved.emit({
+      item: this.dragItem
+    } as ListViewEvent);
+  }
+
+  isDragOriginal(item: any): boolean {
+    return (item === this.dragItem);
+  }
+
+  dragStart(item: any): void {
+    this.dragItem = item;
+    this.onDragStart.emit({
+      item: this.dragItem
+    } as ListViewEvent);
+  }
+
+  // Row Selection
+
+  itemClick($event: MouseEvent, item: any): void {
+    let alreadySelected;
+    let selectionChanged = false;
+
+    // Ignore disabled item clicks completely
+    if (item.disabled === true) {
+      return;
+    }
+
+    if (this.config.selectItems) {
+      if (this.config.multiSelect && !this.config.dblClick) {
+        for (let i = 0; i < this.config.selectedItems.length - 1; i++) {
+          if (this.config.selectedItems[i] === item) {
+            alreadySelected = true;
+            break;
+          }
+        }
+        if (alreadySelected) {
+          // already selected so deselect
+          this.config.selectedItems = without(this.config.selectedItems, item);
+        } else {
+          // add the item to the selected items
+          this.config.selectedItems.push(item);
+          selectionChanged = true;
+        }
+      } else {
+        if (this.config.selectedItems[0] === item) {
+          if (!this.config.dblClick) {
+            this.config.selectedItems = [];
+            selectionChanged = true;
+          }
+        } else {
+          this.config.selectedItems = [item];
+          selectionChanged = true;
+        }
+      }
+
+      if (selectionChanged === true) {
+        this.onSelect.emit({
+          item: item
+        } as ListViewEvent);
+        this.onSelectionChange.emit({
+          item: item,
+          selectedItems: this.config.selectedItems
+        } as ListViewEvent);
+      }
+    }
+    this.onClick.emit({
+      item: item
+    } as ListViewEvent);
+  }
+
+  dblClick($event: MouseEvent, item: any): void {
+    // Ignore disabled item clicks
+    if (this.config.dblClick === true && item.disabled !== true) {
+      this.onDblClick.emit({
+        item: item
+      } as ListViewEvent);
+    }
+  }
+
+  // Toggle
+
+  closeExpandingRow(item: any): void {
+    item.expandingRowId = undefined;
+    item.isRowExpanded = false;
+  }
+
+  toggleExpandingRow(item: any): void {
+    // Row may already be open due to compound expansion
+    if (item.isRowExpanded && item.expandingRowId !== undefined) {
+      item.expandingRowId = undefined;
+      return;
+    }
+    item.expandingRowId = undefined;
+    item.isRowExpanded = !item.isRowExpanded;
+  }
+}

--- a/src/app/list-view/list-view.module.ts
+++ b/src/app/list-view/list-view.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { EmptyStateModule } from '../empty-state/empty-state.module';
+import { ListViewActionsComponent } from './list-view-actions.component';
+import { ListViewComponent } from './list-view.component';
+import { ListViewCompoundToggleComponent } from './list-view-compound-toggle.component';
+import { ListViewConfig } from './list-view-config';
+import { ListViewEvent } from './list-view-event';
+
+export {
+  ListViewConfig,
+  ListViewEvent
+}
+
+@NgModule({
+  imports: [ BsDropdownModule, CommonModule, EmptyStateModule, FormsModule ],
+  declarations: [ ListViewActionsComponent, ListViewComponent, ListViewCompoundToggleComponent ],
+  exports: [ ListViewActionsComponent, ListViewComponent, ListViewCompoundToggleComponent ],
+  providers: [ BsDropdownConfig ]
+})
+export class ListViewModule { }

--- a/src/app/models/action.ts
+++ b/src/app/models/action.ts
@@ -1,3 +1,5 @@
+import { TemplateRef } from '@angular/core';
+
 /*
  * An action for a button, dropdown, etc:
  *
@@ -5,7 +7,8 @@
  * id - Optional unique Id for the filter field, useful for comparisons
  * name - The name of the action, displayed on the button
  * separator - Set to true if this is a placehodler for a separator rather than an action
- * template - Optional template name for including custom content (listView only)
+ * styleClass - Optional style class for action (listView only)
+ * template - Optional template name for including custom content (list-view only)
  * title - Optional title, used for the tooltip
  * visible - Set to false if this menu option should be hidden
  */
@@ -13,8 +16,9 @@ export class Action {
   disabled?: boolean;
   id?: string;
   name: string;
-  separator?: boolean;
-  template?: string;
+  separator?: boolean ;
+  styleClass?: string;
+  template?: TemplateRef<any>;
   title?: string;
   visible?: boolean;
 }

--- a/src/app/models/actions-config.ts
+++ b/src/app/models/actions-config.ts
@@ -3,10 +3,16 @@ import { Action } from './action';
 /*
  * An actions config containing:
  *
- * moreActions - Optional list of secondary actions to display on the toolbar action pulldown menu
- * primaryActions - List of primary actions to display on the toolbar
+ * moreActions - Optional list of secondary kebab actions
+ * moreActionsDisabledFn - Set to true to disable secondary actions kebab (list-view only)
+ * moreActionsStyleClassFn - Optional style class for secondary actions kebab (list-view only)
+ * moreActionsVisibleFn - Set to false to hide secondary actions kebab (list-view only)
+ * primaryActions - List of primary button actions
  */
 export class ActionsConfig {
   moreActions?: Action[];
+  moreActionsDisabled: boolean;
+  moreActionsStyleClass: string;
+  moreActionsVisible: boolean;
   primaryActions: Action[];
 }

--- a/src/assets/stylesheets/patternfly-ng.less
+++ b/src/assets/stylesheets/patternfly-ng.less
@@ -1,2 +1,2 @@
-@import "../../../node_modules/patternfly/dist/less/color-variables.less";
+@import "../../../node_modules/patternfly/dist/less/variables.less";
 @import "_mixins";

--- a/src/demo/app-routing.module.ts
+++ b/src/demo/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { EmptyStateExampleComponent } from '../app/empty-state/examples/empty-state-example.component';
 import { FilterExampleComponent } from '../app/filters/examples/filter-example.component';
+import { ListViewExampleComponent } from '../app/list-view/examples/list-view-example.component';
 import { RemainingCharsExampleComponent } from '../app/remaining-chars/examples/remaining-chars-example.component';
 import { SampleExampleComponent } from '../app/sample/examples/sample-example.component';
 import { SearchHighlightExampleComponent } from '../app/pipes/examples/search-highlight-example.component';
@@ -21,6 +22,9 @@ const routes: Routes = [{
   }, {
     path: 'filters',
     component: FilterExampleComponent
+  }, {
+    path: 'listview',
+    component: ListViewExampleComponent
   }, {
     path: 'remainingchars',
     component: RemainingCharsExampleComponent

--- a/src/demo/app.component.html
+++ b/src/demo/app.component.html
@@ -23,6 +23,9 @@
           <a routerLink="/filters" routerLinkActive="active">Filter</a>
         </li>
         <li>
+          <a routerLink="/listview" routerLinkActive="active">List View</a>
+        </li>
+        <li>
           <a routerLink="/sample" routerLinkActive="active">Sample</a>
         </li>
         <li>

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -14,6 +14,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { EmptyStateExampleModule } from '../app/empty-state/examples/empty-state-example.module';
 import { FilterExampleModule } from '../app/filters/examples/filter-example.module';
 import { NotificationExampleModule } from '../app/notification/examples/notification-example.module';
+import { ListViewExampleModule } from '../app/list-view/examples/list-view-example.module';
 import { RemainingCharsExampleModule } from '../app/remaining-chars/examples/remaining-chars-example.module';
 import { SampleExampleModule } from '../app/sample/examples/sample-example.module';
 import { SearchHighlightExampleModule } from '../app/pipes/examples/search-highlight-example.module';
@@ -30,6 +31,7 @@ import { WelcomeComponent } from './components/welcome.component';
     FormsModule,
     HttpModule,
     NotificationExampleModule,
+    ListViewExampleModule,
     RemainingCharsExampleModule,
     SampleExampleModule,
     SearchHighlightExampleModule,


### PR DESCRIPTION
Added components for list-view, list-view-actions & list-view-compound-toggle. These components render inline actions (to help change dropdown menu direction) and compound row expansion.

Note: These changes depend on the empty-state component from PR #24. The empty-state component must be merged first. Until then, Travis will not build successfully.

This fixes https://github.com/fabric8io/fabric8-ux/issues/501

Example:
https://rawgit.com/dlabrecq/patternfly-ng/list-view-dist/dist-demo/

Basic Example:
![listview basic](https://user-images.githubusercontent.com/17481322/27403822-d90cdca0-5699-11e7-8a81-a7a9e3dbd9ae.png)

Compound Expansion Example:
![listview compound](https://user-images.githubusercontent.com/17481322/27403817-d36f13e4-5699-11e7-855f-49c1333c419b.png)
