### PR TITLE
Adding first community meeting agenda notes

### DIFF
--- a/resources/community-meetings/patternfly-ng_communitymeetingagenda_2017-08.md
+++ b/resources/community-meetings/patternfly-ng_communitymeetingagenda_2017-08.md
@@ -1,0 +1,15 @@
+# patternfy-ng Community Meeting - August 2, 2017
+
+This will be our first community meeting for patternfly-ng!  Please join us to learn about this community, what we are doing, and how you can get involved.
+
+## Agenda:
+1. Welcome & Introductions
+2. Repo status update
+  * Release and consumption information
+  * Contribution process established
+  * Showcase
+  * Semantic release explanation - this could fit in the top point if you’d like
+3. Consumption process demo
+4. Contribution process
+5. Next steps & how to get involved
+6. Open time for questions and discussion on topics the community is interested in


### PR DESCRIPTION
Added a resources folder where we can put other information related to the repo.  Starting with the community meetings agenda.