### PR TITLE
Remove font size from filter fields component

### DIFF
--- a/src/app/filter/filter-fields.component.less
+++ b/src/app/filter/filter-fields.component.less
@@ -7,7 +7,6 @@
       padding-left: 0;
       width: 275px;
     }
-    .btn-default { font-size: 12px; }
     .typeahead-input-container {
       position: relative;
       padding-right: 0;
@@ -26,7 +25,6 @@
     background-color: @color-pf-white;
     background-image: none;
     color: @color-pf-black-500;
-    font-size: 12px;
     font-style: italic;
     font-weight: 400;
   }


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/ngx-widgets/issues/73

The filter fields component overrides OSIO font size.