### PR TITLE
Copy shrink-wrap to dist and use nsp to test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
+node_js:
+  - '6'
+
 cache:
   directories:
     - node_modules
 
 notifications:
   email: false
-
-node_js:
-  - '6'
 
 env:
   global:
@@ -24,10 +24,10 @@ install: true
 script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -x
 
-before_script:
-  - npm prune
-
 after_success:
+  - if [[ -s package.json ]]; then cp package.json dist; fi
+  - if [[ -s npm-shrinkwrap.json ]]; then cp package.json dist; fi
+  - npm prune
   - npm run semantic-release
   - npm run publish-travis
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start:demo": "webpack-dev-server --config config/webpack.demo.js --progress --host 0.0.0.0 --port 8001 --profile --watch --content-base dist-demo",
     "test": "karma start",
     "transpile": "gulp transpile",
-    "semantic-release": "semantic-release pre && cp package.json dist && npm publish dist/ && semantic-release post",
+    "semantic-release": "semantic-release pre && npm publish dist/ && semantic-release post",
     "semantic-release-build": "npm run build"
   },
   "license": "Apache-2.0",
@@ -133,6 +133,7 @@
     "mocha": "3.2.0",
     "ng-router-loader": "2.1.0",
     "npm-run-all": "4.0.2",
+    "nsp": "2.7.0",
     "null-loader": "0.1.1",
     "opt-cli": "1.5.1",
     "optimize-js-plugin": "0.0.4",


### PR DESCRIPTION
Copying shrink-wrap to dist because that's where we publish npm from. Also added nsp to test the generated npm-shrinkwrap.json file for vulnerabilities.