### PR TITLE
Jump start failing semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly-ng",
-  "version": "0.0.0-semantically-released",
+  "version": "0.0.1-semantically-released",
   "description": "A collection of PatternFly Angular components and other useful things to be shared.",
   "main": "bundles/patternfly-ng.umd.js",
   "module": "index.js",


### PR DESCRIPTION
Jump start failing semantic release by changing the version inside package.json. The version inside the package.json doesn't have anything to do with what's published.

Seeing the following error in Travis:

npm ERR! "You cannot publish over the previously published version 0.0.0-semantically-released." : patternfly-ng