### PR TITLE
Semantic-release bumps minor version when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -x
 
 after_success:
+  - git show-ref --head --heads | while IFS=' ' read -r hash name; do test ! -e "${GIT_DIR:-.git}/$name" && echo $hash > "${GIT_DIR:-.git}/$name"; done
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
        npm prune;
        npm run semantic-release;


### PR DESCRIPTION
For each release, the minor version number is incremented. Trying the workaround below.

https://github.com/semantic-release/semantic-release/issues/256