### PR TITLE
Support semantic-release from dist subdirectory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -x
 
 after_success:
-  - git show-ref --head --heads | while IFS=' ' read -r hash name; do test ! -e "${GIT_DIR:-.git}/$name" && echo $hash > "${GIT_DIR:-.git}/$name"; done
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
-       npm run semantic-release;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh -d;
      fi'
   - npm run publish-travis
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "rimraf": "rimraf",
     "start:demo": "webpack-dev-server --config config/webpack.demo.js --progress --host 0.0.0.0 --port 8001 --profile --watch --content-base dist-demo",
     "test": "karma start",
-    "transpile": "gulp transpile",
-    "semantic-release": "semantic-release pre && cp package.json npm-shrinkwrap.json dist && npm publish dist/ && semantic-release post"
+    "transpile": "gulp transpile"
   },
   "license": "Apache-2.0",
   "contributors": [],
@@ -138,7 +137,7 @@
     "optimize-js-plugin": "0.0.4",
     "parse5": "2.2.3",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "^3.26.25",
+    "patternfly-eng-release": "^3.26.30",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "6.0.6",
     "postcss-loader": "1.3.3",


### PR DESCRIPTION
Bumped patterfnly-eng-release to support semantic-release from dist sub-directory.

Fixes issue https://github.com/patternfly/patternfly-ng/issues/102
