### PR TITLE
bump patternfly-eng-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ script:
 
 after_success:
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
+       npm run semantic-release-pre;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh -d;
+       npm run semantic-release-post;
      fi'
   - npm run publish-travis
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "rimraf": "rimraf",
     "start:demo": "webpack-dev-server --config config/webpack.demo.js --progress --host 0.0.0.0 --port 8001 --profile --watch --content-base dist-demo",
     "test": "karma start",
-    "transpile": "gulp transpile"
+    "transpile": "gulp transpile",
+    "semantic-release": "semantic-release pre && copy package.json npm-shrinkwrap.json dist && npm publish dist && semantic-release post",
+    "semantic-release-post": "semantic-release post",
+    "semantic-release-pre": "semantic-release pre"
   },
   "license": "Apache-2.0",
   "contributors": [],
@@ -137,7 +140,7 @@
     "optimize-js-plugin": "0.0.4",
     "parse5": "2.2.3",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "^3.26.31",
+    "patternfly-eng-release": "^3.26.32",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "6.0.6",
     "postcss-loader": "1.3.3",


### PR DESCRIPTION
bump patternfly-eng-release for latest build changes. 

Using the patternfly-eng-release publish-npm.sh script to copy .git, npm-shrinkwrap, package.json, and .npm ignore to dist directory, then npm publish.