### PR TITLE
Bump patternfly-eng-release to run ‘npm publish dist’

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 after_success:
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
        npm run semantic-release-pre;
-       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh -d;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh -d || travis_terminate 0;
        npm run semantic-release-post;
      fi'
   - npm run publish-travis

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "optimize-js-plugin": "0.0.4",
     "parse5": "2.2.3",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "^3.26.32",
+    "patternfly-eng-release": "^3.26.33",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "6.0.6",
     "postcss-loader": "1.3.3",


### PR DESCRIPTION
Bump patternfly-eng-release. 

This will run ‘npm publish dist’ Vs 'cd dist; npm publish'. Don't have token access within dist directory.