### PR TITLE
don't copy package.json to dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,8 +164,7 @@ gulp.task('copy-examples', function () {
 gulp.task('copy-static-assets', function () {
   return gulp.src([
     'LICENSE',
-    'README.md',
-    'package.json',
+    'README.md'
   ])
     .pipe(gulp.dest(libraryDist));
 });


### PR DESCRIPTION
Since we must run `npm publish` from the root, we're copying the contents of dist to root as well. Adding the package.json file to dist during build time ultimately overrides the version in the package.json updated by semantic-release.