### PR TITLE
Remove npm-shrinkwrap.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "optimize-js-plugin": "0.0.4",
     "parse5": "2.2.3",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "^3.26.34",
+    "patternfly-eng-release": "^3.26.35",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "6.0.6",
     "postcss-loader": "1.3.3",


### PR DESCRIPTION
There seems to be a conflict with npm-shrinkwrap which prevents angular-cli from loading modules properly. Omitting for now.