### PR TITLE
Prevent filter fields tooltip from wrapping

### DIFF
--- a/src/app/filter/filter-fields.component.less
+++ b/src/app/filter/filter-fields.component.less
@@ -7,6 +7,9 @@
       padding-left: 0;
       width: 275px;
     }
+    .tooltip {
+      white-space: nowrap;
+    }
     .typeahead-input-container {
       position: relative;
       padding-right: 0;


### PR DESCRIPTION
This PR resolves https://github.com/patternfly/patternfly-ng/pull/118. The filter fields tooltip is wrapping even though there is plenty of room to display it in the patternfly-ng demo.

https://rawgit.com/dlabrecq/patternfly-ng/filter-dist/dist-demo/#/filters