### PR TITLE
Inconsistent filter caret styling

### DIFF
--- a/src/app/filter/filter-fields.component.less
+++ b/src/app/filter/filter-fields.component.less
@@ -14,9 +14,11 @@
       position: relative;
       padding-right: 0;
       .caret {
+        color: @color-pf-black-500;
+        font-style: italic;
         position: absolute;
         top: 10px;
-        right: 5px;
+        right: 12px;
         z-index: 2;
       }
     }


### PR DESCRIPTION
The filter caret styling isn't consistent for the types 'select' and 'typeahead'. They should both italic fonts.

Fixes https://github.com/patternfly/patternfly-ng/issues/131

![screen shot 2017-09-06 at 1 59 34 pm](https://user-images.githubusercontent.com/17481322/30127113-10fec12e-930c-11e7-87ac-8d8315f4113e.png)

Example:
https://rawgit.com/dlabrecq/patternfly-ng/filter-131-dist/dist-demo/#/toolbar