### PR TITLE
fix(modules): add missing .forRoot() calls for BsDropdownModule

### DIFF
--- a/src/app/action/action.module.ts
+++ b/src/app/action/action.module.ts
@@ -17,7 +17,11 @@ export {
  * A module containing objects associated with action components
  */
 @NgModule({
-  imports: [ BsDropdownModule, CommonModule, FormsModule ],
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    FormsModule
+  ],
   declarations: [ ActionComponent ],
   exports: [ ActionComponent ],
   providers: [ BsDropdownConfig ]

--- a/src/app/card/card.module.ts
+++ b/src/app/card/card.module.ts
@@ -28,7 +28,7 @@ export {
  */
 @NgModule({
   imports: [
-    BsDropdownModule,
+    BsDropdownModule.forRoot(),
     CommonModule,
     FormsModule
   ],

--- a/src/app/list/list.module.ts
+++ b/src/app/list/list.module.ts
@@ -28,7 +28,7 @@ export {
  */
 @NgModule({
   imports: [
-    BsDropdownModule,
+    BsDropdownModule.forRoot(),
     CommonModule,
     EmptyStateModule,
     FormsModule,

--- a/src/app/toolbar/toolbar.module.ts
+++ b/src/app/toolbar/toolbar.module.ts
@@ -17,7 +17,13 @@ export {
  * A module containing objects associated with the toolbar component
  */
 @NgModule({
-  imports: [ ActionModule, BsDropdownModule, CommonModule, FilterModule, SortModule ],
+  imports: [
+    ActionModule,
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    FilterModule,
+    SortModule
+  ],
   declarations: [ ToolbarComponent ],
   exports: [ ToolbarComponent ],
   providers: [ BsDropdownConfig ]


### PR DESCRIPTION
Added missing .forRoot() calls for BsDropdownModule. This is causing errors, specifically when using the pfng-action component with the tree list.

The reported error:
Reaction[TreeNodeCollectionComponent.detectChanges()] Error: No provider for ComponentLoaderFactory!
