### PR TITLE
Underlying tree component should be private

### DIFF
--- a/src/app/list/tree-list/tree-list.component.ts
+++ b/src/app/list/tree-list/tree-list.component.ts
@@ -67,7 +67,7 @@ export class TreeListComponent extends ListBase implements DoCheck, OnInit {
   /**
    * The underlying tree for angular-tree-component
    */
-  @ViewChild(TreeComponent) tree: TreeComponent;
+  @ViewChild(TreeComponent) private tree: TreeComponent;
 
   private defaultConfig = {
     dblClick: false,


### PR DESCRIPTION
The ViewChild for the underlying tree component should be private. We already have accessors to update the underlying tree model.