### PR TITLE
Ensure list items are not undefined

### DIFF
--- a/src/app/list/list-base.ts
+++ b/src/app/list/list-base.ts
@@ -62,9 +62,9 @@ export abstract class ListBase {
   protected setupConfig(): void {
     let config = this.getConfig();
     if (config.multiSelect === undefined || config.multiSelect === false) {
-      let items = this.getSelectedItems(this.items);
-      if (items.length > 0) {
-        this.selectSingleItem(items[0]);
+      let selectedItems = this.getSelectedItems(this.items);
+      if (selectedItems.length > 0) {
+        this.selectSingleItem(selectedItems[0]);
       }
     }
     if (config.multiSelect && config.dblClick) {
@@ -143,10 +143,12 @@ export abstract class ListBase {
    * @param {any[]} items The items to be deselected
    */
   protected deselectItems(items: any[]): void {
-    for (let i = 0; i < items.length; i++) {
-      items[i].selected = false;
-      if (Array.isArray(items[i].children)) {
-        this.deselectItems(items[i].children);
+    if (items !== undefined) {
+      for (let i = 0; i < items.length; i++) {
+        items[i].selected = false;
+        if (Array.isArray(items[i].children)) {
+          this.deselectItems(items[i].children);
+        }
       }
     }
   }
@@ -159,13 +161,15 @@ export abstract class ListBase {
    */
   protected getSelectedItems(items: any[]): any[] {
     let selectedItems = [];
-    for (let i = 0; i < items.length; i++) {
-      if (items[i].selected) {
-        selectedItems.push(items[i]);
-      }
-      if (Array.isArray(items[i].children)) {
-        let selectedChildren = this.getSelectedItems(items[i].children);
-        selectedItems = selectedItems.concat(selectedChildren);
+    if (items !== undefined) {
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].selected) {
+          selectedItems.push(items[i]);
+        }
+        if (Array.isArray(items[i].children)) {
+          let selectedChildren = this.getSelectedItems(items[i].children);
+          selectedItems = selectedItems.concat(selectedChildren);
+        }
       }
     }
     return selectedItems;


### PR DESCRIPTION
When navigating away from the current page, list items may become undefined. The config setup runs whenever there is a change, which generates an error when items are undefined.