### PR TITLE
Included content not displayed

### DIFF
--- a/src/demo/components/includeContent.component.ts
+++ b/src/demo/components/includeContent.component.ts
@@ -10,10 +10,9 @@ import { Http, Response } from '@angular/http';
     <pre><code>{{templateContent}}</code></pre>`
 })
 export class IncludeContentComponent implements OnInit {
-  @Input() src: string;
+  @Input('src') templateUrl: string;
 
   page: string;
-  templateUrl: string;
   templateContent: string;
 
   constructor(private http: Http) {}


### PR DESCRIPTION
Fixed src property for include-content component.

AOT fixes to the example app required a syntax change from "@Input('src')" to "@Input() src: string". As a result, we lost the alias to the templateUrl var -- this fix restores that.