### PR TITLE
WizardStep must be a class

### DIFF
--- a/src/app/wizard/wizard-step.ts
+++ b/src/app/wizard/wizard-step.ts
@@ -2,13 +2,12 @@ import {
   TemplateRef
 } from '@angular/core';
 
-import { WizardComponent } from './wizard.component';
 import { WizardStepConfig } from './wizard-step-config';
 
 /**
  * Wizard step
  */
-export interface WizardStep {
+export class WizardStep {
   /**
    * The wizard step config containing component properties
    */


### PR DESCRIPTION
The WizardStep object must be a class Vs interface to be included in the transpiled index.js file. All other component config objects use classes.