### PR TITLE
Check for undefined secondary actions

### DIFF
--- a/src/app/empty-state/empty-state.component.html
+++ b/src/app/empty-state/empty-state.component.html
@@ -28,7 +28,7 @@
   </div>
     <div class="blank-slate-pf-secondary-action {{config.actions?.moreActionsStyleClass}}"
        [ngClass]="{'hidden': config.actions?.moreActionsVisible === false}"
-       *ngIf="config.actions?.moreActions.length > 0">
+       *ngIf="config.actions?.moreActions?.length > 0">
     <button *ngFor="let action of config.actions.moreActions"
             class="btn btn-default {{action.styleClass}}" title="{{action.tooltip}}"
             [disabled]="action.disabled"


### PR DESCRIPTION
This resolves an error generated when moreActions is (undefined) not provided to the actionConfig object.