### PR TITLE
Add donut chart pattern

### DIFF
--- a/src/app/chart/chart.module.ts
+++ b/src/app/chart/chart.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { DonutComponent } from './donut/donut.component';
 import { SparklineComponent } from './sparkline/sparkline.component';
 import { ChartDefaults } from './chart.defaults';
 
@@ -9,8 +10,8 @@ import { ChartDefaults } from './chart.defaults';
     CommonModule,
     FormsModule,
   ],
-  declarations: [SparklineComponent],
-  exports: [SparklineComponent],
+  declarations: [SparklineComponent, DonutComponent],
+  exports: [SparklineComponent, DonutComponent],
   providers: [ChartDefaults]
 })
 export class ChartModule {}

--- a/src/app/chart/donut/donut-config.ts
+++ b/src/app/chart/donut/donut-config.ts
@@ -5,9 +5,9 @@ import { ChartConfig } from '../chart-config';
 export class DonutConfig extends ChartConfig {
 
   /**
-   * An optional function to customize the text of the center label
+   * Text for the donut chart center label (optional)
    */
-  centerLabelFn?: any;
+  centerLabel?: any;
 
   /**
    * An optional function to handle when donut is clicked
@@ -15,12 +15,18 @@ export class DonutConfig extends ChartConfig {
   onClickFn?: any;
 
   /**
-   * The height of the donut chart
+   * The height of the donut chart (optional)
    */
   chartHeight?: number;
 
   /**
    * C3 inherited configuration for colors
+   * An object with key-value pairs of data name and color, e.g.
+   * colors : {
+   *   Cats: '#0088ce',
+   *   Hamsters: '#3f9c35',
+   * }
+   *
    */
   colors?: any;
 

--- a/src/app/chart/donut/donut-config.ts
+++ b/src/app/chart/donut/donut-config.ts
@@ -1,0 +1,36 @@
+import { ChartConfig } from '../chart-config';
+/**
+ * A config containing properties for the sparkline chart
+ */
+export class DonutConfig extends ChartConfig {
+
+  /**
+   * An optional function to customize the text of the center label
+   */
+  centerLabelFn?: any;
+
+  /**
+   * An optional function to handle when donut is clicked
+   */
+  onClickFn?: any;
+
+  /**
+   * The height of the donut chart
+   */
+  chartHeight?: number;
+
+  /**
+   * C3 inherited configuration for colors
+   */
+  colors?: any;
+
+  /**
+   * C3 inherited configuration for size
+   */
+  size?: any;
+
+  /**
+   * C3 inherited donut configuration
+   */
+  donut?: any;
+}

--- a/src/app/chart/donut/donut-config.ts
+++ b/src/app/chart/donut/donut-config.ts
@@ -39,4 +39,9 @@ export class DonutConfig extends ChartConfig {
    * C3 inherited donut configuration
    */
   donut?: any;
+
+  /**
+   * C3 inherited configuration for tooltip
+   */
+  tooltip?: any;
 }

--- a/src/app/chart/donut/donut.component.html
+++ b/src/app/chart/donut/donut.component.html
@@ -1,0 +1,1 @@
+<div #chartElement id="{{donutChartId}}"></div>

--- a/src/app/chart/donut/donut.component.html
+++ b/src/app/chart/donut/donut.component.html
@@ -1,1 +1,1 @@
-<div #chartElement id="{{donutChartId}}"></div>
+<div #chartElement id="{{config.chartId}}"></div>

--- a/src/app/chart/donut/donut.component.spec.ts
+++ b/src/app/chart/donut/donut.component.spec.ts
@@ -20,11 +20,13 @@ describe('Component: donut chart', () => {
 
   beforeEach(() => {
     config = {
-      'chartId': 'testDonutChart',
-      data: {},
+      chartId: 'testDonutChart',
       onClickFn: function(d: any, e: any) {
       },
-      centerLabel: 'center'
+      data: {},
+      donut: {
+        title: 'Animals'
+      }
     };
     data = [
       ['Cats', 2],
@@ -50,6 +52,10 @@ describe('Component: donut chart', () => {
       });
   }));
 
+  it('should set chart id', () => {
+    expect(comp.donutChartId).toBe('testDonutChartdonutChart');
+  });
+
 
   it('should allow attribute specification of chart height', () => {
     config.chartHeight = 120;
@@ -61,14 +67,12 @@ describe('Component: donut chart', () => {
     config.chartHeight = 120;
 
     fixture.detectChanges();
-    expect(comp.donutChartId).toBe('testDonutChartdonutChart');
     expect(comp.config.size.height).toBe(120);
 
     config.chartHeight = 100;
     fixture.detectChanges();
     expect(comp.config.size.height).toBe(100);
   });
-
 
   it('should setup C3 chart data correctly', () => {
     expect(comp.config.data.columns.length).toBe(3);
@@ -89,5 +93,31 @@ describe('Component: donut chart', () => {
 
   it('should setup onclick correctly', () => {
     expect(typeof(comp.config.data.onclick)).toBe('function');
+  });
+
+  it('should use the default centerLabel', () => {
+    let centerLabel = comp.getCenterLabelText();
+    expect(centerLabel.bigText).toBe(6);
+    expect(centerLabel.smText).toBe('Animals');
+  });
+
+  it('should use custom centerLabel', () => {
+    config.centerLabel = 'custom-label';
+    fixture.detectChanges();
+
+    let centerLabel = comp.getCenterLabelText();
+    expect(centerLabel.bigText).toBe('custom-label');
+    expect(centerLabel.smText).toBe('');
+  });
+
+  it('should use patternfly tooltip', () => {
+    expect(typeof(comp.config.tooltip.contents)).toBe('function');
+  });
+
+  it('should have default donut config with custom title', () => {
+    expect(comp.config.donut.title).toBe('Animals');
+
+    expect(comp.config.donut.width).toBe(11);
+    expect(comp.config.donut.label.show).toBe(false);
   });
 });

--- a/src/app/chart/donut/donut.component.spec.ts
+++ b/src/app/chart/donut/donut.component.spec.ts
@@ -53,7 +53,7 @@ describe('Component: donut chart', () => {
   }));
 
   it('should set chart id', () => {
-    expect(comp.donutChartId).toBe('testDonutChartdonutChart');
+    expect(comp.config.chartId).toContain('testDonutChart');
   });
 
 

--- a/src/app/chart/donut/donut.component.spec.ts
+++ b/src/app/chart/donut/donut.component.spec.ts
@@ -24,8 +24,7 @@ describe('Component: donut chart', () => {
       data: {},
       onClickFn: function(d: any, e: any) {
       },
-      centerLabelFn: function() {
-      }
+      centerLabel: 'center'
     };
     data = [
       ['Cats', 2],

--- a/src/app/chart/donut/donut.component.spec.ts
+++ b/src/app/chart/donut/donut.component.spec.ts
@@ -1,0 +1,94 @@
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { DonutConfig } from './donut-config';
+import { DonutComponent } from './donut.component';
+import { ChartDefaults } from '../chart.defaults';
+
+describe('Component: donut chart', () => {
+
+  let comp: DonutComponent;
+  let fixture: ComponentFixture<DonutComponent>;
+
+  let config: DonutConfig;
+  let data: any;
+
+  beforeEach(() => {
+    config = {
+      'chartId': 'testDonutChart',
+      data: {},
+      onClickFn: function(d: any, e: any) {
+      },
+      centerLabelFn: function() {
+      }
+    };
+    data = [
+      ['Cats', 2],
+      ['Hamsters', 2],
+      ['Dogs', 2]
+    ];
+  });
+
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule, FormsModule],
+      declarations: [DonutComponent],
+      providers: [ChartDefaults]
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(DonutComponent);
+        comp = fixture.componentInstance;
+        comp.config = config;
+        comp.chartData = data;
+        fixture.detectChanges();
+      });
+  }));
+
+
+  it('should allow attribute specification of chart height', () => {
+    config.chartHeight = 120;
+    fixture.detectChanges();
+    expect(comp.config.size.height).toBe(120);
+  });
+
+  it('should update when the chart height attribute changes', () => {
+    config.chartHeight = 120;
+
+    fixture.detectChanges();
+    expect(comp.donutChartId).toBe('testDonutChartdonutChart');
+    expect(comp.config.size.height).toBe(120);
+
+    config.chartHeight = 100;
+    fixture.detectChanges();
+    expect(comp.config.size.height).toBe(100);
+  });
+
+
+  it('should setup C3 chart data correctly', () => {
+    expect(comp.config.data.columns.length).toBe(3);
+    expect(comp.config.data.columns[0][0]).toBe('Cats');
+    expect(comp.config.data.columns[1][0]).toBe('Hamsters');
+  });
+
+  it('should update C3 chart data when data changes', () => {
+    expect(comp.config.data.columns.length).toBe(3);
+    expect(comp.config.data.columns[0][0]).toBe('Cats');
+    expect(comp.config.data.columns[0][1]).toBe(2);
+
+    data[0][1] = 3;
+    fixture.detectChanges();
+
+    expect(comp.config.data.columns[0][1]).toBe(3);
+  });
+
+  it('should setup onclick correctly', () => {
+    expect(typeof(comp.config.data.onclick)).toBe('function');
+  });
+});

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -1,6 +1,6 @@
 import { Component, DoCheck, Input, OnInit } from '@angular/core';
 
-import { cloneDeep, defaults, isEqual, merge } from 'lodash';
+import { cloneDeep, defaults, isEqual, merge, uniqueId } from 'lodash';
 import { Subscription } from 'rxjs/Subscription';
 
 import { ChartDefaults } from '../chart.defaults';
@@ -18,8 +18,6 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
   @Input() chartData: any;
   @Input() config: DonutConfig;
 
-  public donutChartId: any;
-
   private prevChartData: any;
 
   private subscriptions: Subscription[] = [];
@@ -33,10 +31,10 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
   }
 
   ngOnInit(): void {
-    this.donutChartId = 'donutChart';
-    if (this.config.chartId) {
-      this.donutChartId = this.config.chartId + this.donutChartId;
+    if (!this.config.chartId) {
+      throw new Error('DonutComponent: config must have string property chartId');
     }
+    this.config.chartId = uniqueId(this.config.chartId);
 
     this.subscriptions.push(this.chartLoaded.subscribe({
       next: (chart: any) => {
@@ -50,10 +48,10 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
   ngDoCheck(): void {
     if (!isEqual(this.config, this.prevConfig)) {
       this.updateConfig();
-      this.generateChart(this.donutChartId, true);
+      this.generateChart(this.config.chartId, true);
     } else if (!isEqual(this.chartData, this.prevChartData)) {
       this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
-      this.generateChart(this.donutChartId, false);
+      this.generateChart(this.config.chartId, false);
       this.prevChartData = cloneDeep(this.chartData);
     }
   }

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -62,6 +62,21 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
     this.subscriptions.forEach(sub => sub.unsubscribe);
   }
 
+  // Public for testing
+  public getCenterLabelText(): any {
+    let centerLabelText = {
+      bigText: this.getTotal(),
+      smText: this.config.donut.title
+    };
+
+    if (this.config.centerLabel) {
+      centerLabelText.bigText = this.config.centerLabel;
+      centerLabelText.smText = '';
+    }
+
+    return centerLabelText;
+  }
+
   private chartAvailable(chart: any): void {
     this.setupDonutChartTitle(chart);
   }
@@ -75,20 +90,6 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
     });
 
     return total;
-  }
-
-  private getCenterLabelText(): any {
-    let centerLabelText = {
-      bigText: this.getTotal(),
-      smText: this.config.donut.title
-    };
-
-    if (this.config.centerLabel) {
-      centerLabelText.bigText = this.config.centerLabel;
-      centerLabelText.smText = '';
-    }
-
-    return centerLabelText;
   }
 
   private setupDonutChartTitle(chart: any): void {

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -1,0 +1,144 @@
+import { Component, DoCheck, Input, OnInit } from '@angular/core';
+
+import { cloneDeep, defaults, isEqual, merge } from 'lodash';
+import { ChartDefaults } from '../chart.defaults';
+import { ChartBase } from '../chart.base';
+import { DonutConfig } from './donut-config';
+
+import * as d3 from 'd3';
+
+@Component({
+  selector: 'pfng-chart-donut',
+  templateUrl: './donut.component.html'
+})
+export class DonutComponent extends ChartBase implements DoCheck, OnInit {
+
+  @Input() chartData: any;
+  @Input() config: DonutConfig;
+
+  public donutChartId: any;
+
+  private prevChartData: any;
+  private defaultConfig: DonutConfig;
+
+  /**
+   * Default constructor
+   * @param chartDefaults
+   */
+  constructor(private chartDefaults: ChartDefaults) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.donutChartId = 'donutChart';
+    if (this.config.chartId) {
+      this.donutChartId = this.config.chartId + this.donutChartId;
+    }
+
+    this.chartLoaded.subscribe({
+      next: (chart: any) => {
+        this.chartAvailable(chart);
+      }
+    });
+
+    this.setupConfig();
+    super.generateChart(this.donutChartId);
+    this.updateAll();
+  }
+
+  ngDoCheck(): void {
+    if (!isEqual(this.chartData, this.prevChartData)) {
+      this.updateAll();
+    }
+
+    if (!isEqual(this.config, this.prevConfig)) {
+      this.setupConfig();
+      this.generateChart(this.donutChartId, true);
+    }
+  }
+
+  public chartAvailable(chart: any): void {
+    this.setupDonutChartTitle(chart);
+  }
+
+  private getTotal(): number {
+    let total = 0;
+    this.chartData.forEach((element: any) => {
+      if (!isNaN(element[1])) {
+        total += Number(element[1]);
+      }
+    });
+
+    return total;
+  }
+
+  private getCenterLabelText(): any {
+    let centerLabelText = {
+      bigText: this.getTotal(),
+      smText: this.config.donut.title
+    };
+
+    if (this.config.centerLabelFn) {
+      centerLabelText.bigText = this.config.centerLabelFn();
+      centerLabelText.smText = '';
+    }
+
+    return centerLabelText;
+  }
+
+  private setupDonutChartTitle(chart: any): void {
+    let donutChartTitle, centerLabelText;
+
+    if (!chart) {
+      return;
+    }
+
+    donutChartTitle = d3.select(chart.element).select('text.c3-chart-arcs-title');
+    if (!donutChartTitle) {
+      return;
+    }
+
+    centerLabelText = this.getCenterLabelText();
+
+    donutChartTitle.text('');
+    if (centerLabelText.bigText && !centerLabelText.smText) {
+      donutChartTitle.text(centerLabelText.bigText);
+    } else {
+      donutChartTitle.insert('tspan', null).text(centerLabelText.bigText)
+        .classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
+      donutChartTitle.insert('tspan', null).text(centerLabelText.smText).
+        classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+    }
+  }
+
+  private setupConfig(): void {
+    this.defaultConfig = this.chartDefaults.getDefaultDonutConfig();
+    let defaultDonut = this.chartDefaults.getDefaultDonut();
+
+    defaults(this.config, this.defaultConfig);
+    defaults(this.config.donut, defaultDonut);
+
+    if (this.config.chartHeight) {
+      this.defaultConfig.size.height = this.config.chartHeight;
+      this.config.size.height = this.config.chartHeight;
+    }
+  }
+
+  private getDonutData(chartData: any): any {
+    return {
+      type: 'donut',
+      columns: this.chartData,
+      order: null,
+      colors: this.config.colors
+    };
+  }
+
+  private updateAll(): void {
+    this.prevChartData = cloneDeep(this.chartData);
+
+    this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
+    this.config.data.onclick = this.config.onClickFn;
+  }
+
+
+}

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -134,15 +134,16 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
   }
 
   private updateConfig(): void {
+    this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
 
     if (this.config.chartHeight) {
       this.config.size.height = this.config.chartHeight;
     }
 
-    this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
-
     if (this.config.onClickFn) {
       this.config.data.onclick = this.config.onClickFn;
     }
+
+    this.config.tooltip = { contents: (window as any).patternfly.pfDonutTooltipContents };
   }
 }

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -83,8 +83,8 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
       smText: this.config.donut.title
     };
 
-    if (this.config.centerLabelFn) {
-      centerLabelText.bigText = this.config.centerLabelFn();
+    if (this.config.centerLabel) {
+      centerLabelText.bigText = this.config.centerLabel;
       centerLabelText.smText = '';
     }
 
@@ -134,6 +134,7 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
   }
 
   private updateConfig(): void {
+
     if (this.config.chartHeight) {
       this.config.size.height = this.config.chartHeight;
     }

--- a/src/app/chart/donut/examples/donut-example.component.html
+++ b/src/app/chart/donut/examples/donut-example.component.html
@@ -1,0 +1,35 @@
+<div class="padding-15">
+  <div class="row padding-bottom-15">
+    <div class="col-xs-12">
+      <h4>Donut Chart Example</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <pfng-chart-donut [config]="config" [chartData]="data"></pfng-chart-donut>
+      </div>
+    </div>
+  </div>
+
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="api">
+        <iframe class="demoframe" src="docs/classes/donutcomponent.html"></iframe>
+      </tab>
+      <tab heading="html">
+        <include-content src="src/app/chart/donut/examples/donut-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="src/app/chart/donut/examples/donut-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/chart/donut/examples/donut-example.component.html
+++ b/src/app/chart/donut/examples/donut-example.component.html
@@ -6,10 +6,19 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-12">
-      <div class="form-group">
-        <pfng-chart-donut [config]="config" [chartData]="data"></pfng-chart-donut>
-      </div>
+    <div class="col-md-6 text-center">
+      <label>Donut Chart</label>
+    </div>
+    <div class="col-md-6 text-center">
+      <label>Small Donut Chart</label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [config]="config" [chartData]="data"></pfng-chart-donut>
+    </div>
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [config]="config2" [chartData]="data"></pfng-chart-donut>
     </div>
   </div>
 

--- a/src/app/chart/donut/examples/donut-example.component.ts
+++ b/src/app/chart/donut/examples/donut-example.component.ts
@@ -1,0 +1,37 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'donut-example',
+  templateUrl: './donut-example.component.html'
+})
+export class DonutExampleComponent implements OnInit {
+  public config: any = {
+    chartId: 'exampleDonut',
+    colors: {
+      Cats: '#0088ce',
+      Hamsters: '#3f9c35'
+    },
+    onClickFn: (data: any, element: any) => {
+      alert('Clicked!');
+    },
+    donut: {
+      title: 'Animals'
+    }
+  };
+  public data: any = [
+    ['Cats', 2],
+    ['Hamsters', 2]
+  ];
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    this.config.chartHeight = 180;
+  }
+}

--- a/src/app/chart/donut/examples/donut-example.component.ts
+++ b/src/app/chart/donut/examples/donut-example.component.ts
@@ -4,6 +4,8 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
+import { cloneDeep } from 'lodash';
+
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'donut-example',
@@ -13,25 +15,44 @@ export class DonutExampleComponent implements OnInit {
   public config: any = {
     chartId: 'exampleDonut',
     colors: {
-      Cats: '#0088ce',
-      Hamsters: '#3f9c35'
+      Cats: '#0088ce',     // blue
+      Hamsters: '#3f9c35', // green
+      Fish: '#ec7a08',     // orange
+      Dogs: '#cc0000'      // red
     },
     onClickFn: (data: any, element: any) => {
-      alert('Clicked!');
+      alert('You clicked on donut arc: ' + data.id);
     },
     donut: {
       title: 'Animals'
+    },
+    legend: {
+      show: true
     }
   };
+
+  public config2: any;
+
   public data: any = [
     ['Cats', 2],
-    ['Hamsters', 2]
+    ['Hamsters', 1],
+    ['Fish', 3],
+    ['Dogs', 2]
   ];
 
   constructor() {
   }
 
   ngOnInit(): void {
-    this.config.chartHeight = 180;
+    this.config2 = cloneDeep(this.config);
+    this.config2.chartId = 'exampleDonut2';
+    this.config2.legend = {
+      show: true,
+      position: 'right'
+    };
+    this.config2.centerLabelFn = () => {
+      return 'Pets';
+    };
+    this.config2.chartHeight = 120;
   }
 }

--- a/src/app/chart/donut/examples/donut-example.component.ts
+++ b/src/app/chart/donut/examples/donut-example.component.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core';
 
 import { cloneDeep } from 'lodash';
+import { Observable } from 'rxjs';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -54,5 +55,15 @@ export class DonutExampleComponent implements OnInit {
       return 'Pets';
     };
     this.config2.chartHeight = 120;
+
+    Observable
+      .timer(0, 1000)
+      .map(() => Math.floor(Math.random() * 5) + 1)
+      .subscribe(val => this.data[0][1] = val);
+
+    Observable
+    .timer(0, 5000)
+    .map(() => Math.floor(Math.random() * 100) + 100)
+    .subscribe(val => this.config2.chartHeight = val);
   }
 }

--- a/src/app/chart/donut/examples/donut-example.module.ts
+++ b/src/app/chart/donut/examples/donut-example.module.ts
@@ -1,19 +1,19 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
 import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
 
+import { ChartModule } from '../../chart.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { DonutExampleComponent } from './donut-example.component';
-import { ChartModule } from '../../chart.module';
 
 @NgModule({
   declarations: [DonutExampleComponent],
   imports: [
-    CommonModule,
-    FormsModule,
-    DemoComponentsModule,
     ChartModule,
+    CommonModule,
+    DemoComponentsModule,
+    FormsModule,
     TabsModule.forRoot()
   ],
   providers: [TabsetConfig]

--- a/src/app/chart/donut/examples/donut-example.module.ts
+++ b/src/app/chart/donut/examples/donut-example.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TabsModule, TabsetConfig } from 'ngx-bootstrap/tabs';
+import { FormsModule } from '@angular/forms';
+
+import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
+import { DonutExampleComponent } from './donut-example.component';
+import { ChartModule } from '../../chart.module';
+
+@NgModule({
+  declarations: [DonutExampleComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    DemoComponentsModule,
+    ChartModule,
+    TabsModule.forRoot()
+  ],
+  providers: [TabsetConfig]
+})
+export class DonutExampleModule {
+  constructor() { }
+}

--- a/src/demo/app-routing.module.ts
+++ b/src/demo/app-routing.module.ts
@@ -20,6 +20,7 @@ import { SearchHighlightExampleComponent }
 import { SortExampleComponent } from '../app/sort/examples/sort-example.component';
 import { SortArrayExampleComponent } from '../app/pipe/sort-array/examples/sort-array-example.component';
 import { SparklineExampleComponent } from '../app/chart/sparkline/examples/sparkline-example.component';
+import { DonutExampleComponent } from '../app/chart/donut/examples/donut-example.component';
 import { ToastNotificationExampleComponent } from '../app/notification/examples/toast-notification-example.component';
 import { ToolbarExampleComponent } from '../app/toolbar/examples/toolbar-example.component';
 import { TreeListExampleComponent } from '../app/list/tree-list/examples/tree-list-example.component';
@@ -85,6 +86,9 @@ const routes: Routes = [{
   }, {
     path: 'sparkline',
     component: SparklineExampleComponent
+  }, {
+    path: 'donut',
+    component: DonutExampleComponent
   }, {
     path: 'toastnotification',
     component: ToastNotificationExampleComponent

--- a/src/demo/app-routing.module.ts
+++ b/src/demo/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { ActionExampleComponent } from '../app/action/examples/action-example.component';
 import { CardExampleComponent } from '../app/card/basic-card/examples/card-example.component';
+import { DonutExampleComponent } from '../app/chart/donut/examples/donut-example.component';
 import { InfoStatusCardExampleComponent }
   from '../app/card/info-status-card/examples/info-status-card-example.component';
 import { EmptyStateExampleComponent } from '../app/empty-state/examples/empty-state-example.component';
@@ -20,7 +21,6 @@ import { SearchHighlightExampleComponent }
 import { SortExampleComponent } from '../app/sort/examples/sort-example.component';
 import { SortArrayExampleComponent } from '../app/pipe/sort-array/examples/sort-array-example.component';
 import { SparklineExampleComponent } from '../app/chart/sparkline/examples/sparkline-example.component';
-import { DonutExampleComponent } from '../app/chart/donut/examples/donut-example.component';
 import { ToastNotificationExampleComponent } from '../app/notification/examples/toast-notification-example.component';
 import { ToolbarExampleComponent } from '../app/toolbar/examples/toolbar-example.component';
 import { TreeListExampleComponent } from '../app/list/tree-list/examples/tree-list-example.component';
@@ -40,6 +40,9 @@ const routes: Routes = [{
   }, {
     path: 'card',
     component: CardExampleComponent
+  }, {
+    path: 'donut',
+    component: DonutExampleComponent
   }, {
     path: 'infocard',
     component: InfoStatusCardExampleComponent
@@ -86,9 +89,6 @@ const routes: Routes = [{
   }, {
     path: 'sparkline',
     component: SparklineExampleComponent
-  }, {
-    path: 'donut',
-    component: DonutExampleComponent
   }, {
     path: 'toastnotification',
     component: ToastNotificationExampleComponent

--- a/src/demo/app.component.html
+++ b/src/demo/app.component.html
@@ -35,10 +35,10 @@
         <li>Charts
           <ul>
             <li>
-              <a routerLink="/sparkline" routerLinkActive="active">Sparkline</a>
+              <a routerLink="/donut" routerLinkActive="active">Donut</a>
             </li>
             <li>
-              <a routerLink="/donut" routerLinkActive="active">Donut</a>
+              <a routerLink="/sparkline" routerLinkActive="active">Sparkline</a>
             </li>
           </ul>
         </li>
@@ -119,4 +119,3 @@
     </div>
   </div>
 </main>
-

--- a/src/demo/app.component.html
+++ b/src/demo/app.component.html
@@ -37,6 +37,9 @@
             <li>
               <a routerLink="/sparkline" routerLinkActive="active">Sparkline</a>
             </li>
+            <li>
+              <a routerLink="/donut" routerLinkActive="active">Donut</a>
+            </li>
           </ul>
         </li>
         <li>

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -27,6 +27,7 @@ import { SearchHighlightExampleModule } from '../app/pipe/search-highlight/examp
 import { SortArrayExampleModule } from '../app/pipe/sort-array/examples/sort-array-example.module';
 import { SortExampleModule } from '../app/sort/examples/sort-example.module';
 import { SparklineExampleModule } from '../app/chart/sparkline/examples/sparkline-example.module';
+import { DonutExampleModule } from '../app/chart/donut/examples/donut-example.module';
 import { ToolbarExampleModule } from '../app/toolbar/examples/toolbar-example.module';
 import { TreeListExampleModule } from '../app/list/tree-list/examples/tree-list-example.module';
 import { TruncateExampleModule } from '../app/pipe/truncate/examples/truncate-example.module';
@@ -55,6 +56,7 @@ import { NavigationExampleModule } from '../app/navigation/examples/navigation-e
     SortArrayExampleModule,
     SortExampleModule,
     SparklineExampleModule,
+    DonutExampleModule,
     ToolbarExampleModule,
     TreeListExampleModule,
     TruncateExampleModule,

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -14,6 +14,7 @@ import { DemoComponentsModule } from './components/demo-components.module';
 //  import example modules
 import { ActionExampleModule } from '../app/action/examples/action-example.module';
 import { CardExampleModule } from '../app/card/basic-card/examples/card-example.module';
+import { DonutExampleModule } from '../app/chart/donut/examples/donut-example.module';
 import { InfoStatusCardExampleModule } from '../app/card/info-status-card/examples/info-status-card-example.module';
 import { EmptyStateExampleModule } from '../app/empty-state/examples/empty-state-example.module';
 import { FilterExampleModule } from '../app/filter/examples/filter-example.module';
@@ -27,7 +28,6 @@ import { SearchHighlightExampleModule } from '../app/pipe/search-highlight/examp
 import { SortArrayExampleModule } from '../app/pipe/sort-array/examples/sort-array-example.module';
 import { SortExampleModule } from '../app/sort/examples/sort-example.module';
 import { SparklineExampleModule } from '../app/chart/sparkline/examples/sparkline-example.module';
-import { DonutExampleModule } from '../app/chart/donut/examples/donut-example.module';
 import { ToolbarExampleModule } from '../app/toolbar/examples/toolbar-example.module';
 import { TreeListExampleModule } from '../app/list/tree-list/examples/tree-list-example.module';
 import { TruncateExampleModule } from '../app/pipe/truncate/examples/truncate-example.module';
@@ -42,6 +42,7 @@ import { NavigationExampleModule } from '../app/navigation/examples/navigation-e
     BrowserModule,
     CardExampleModule,
     DemoComponentsModule,
+    DonutExampleModule,
     EmptyStateExampleModule,
     FilterExampleModule,
     FormsModule,
@@ -56,7 +57,6 @@ import { NavigationExampleModule } from '../app/navigation/examples/navigation-e
     SortArrayExampleModule,
     SortExampleModule,
     SparklineExampleModule,
-    DonutExampleModule,
     ToolbarExampleModule,
     TreeListExampleModule,
     TruncateExampleModule,


### PR DESCRIPTION
This adds the donut chart pattern addressing one half of issue #180

The patterns closely follow the angularJS versions:
http://www.patternfly.org/angular-patternfly/#/api/patternfly.charts.component:pfDonutChart

Notable differences:

* similar to the patternfly-ng sparkline pattern, previously stand-alone options like `chartHeight` are moved under the config as for example `config.chartHeight` or `config.centerLabel`

A demo via rawgit is available via:
http://rawgit.com/jiekang/patternfly-ng/donut-chart-dist/dist-demo/#/donut

Thoughts?