### PR TITLE
Fix es5 build errors

### DIFF
--- a/src/app/card/info-status-card/info-status-card.component.spec.ts
+++ b/src/app/card/info-status-card/info-status-card.component.spec.ts
@@ -62,7 +62,7 @@ describe('Info Status Card Component - ', () => {
   });
 
   it('should set the title, title link, and icons class', () => {
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let numTitles = fixture.debugElement.queryAll(By.css('.pfng-card-title')).length;
     let numTitleLinks = fixture.debugElement.queryAll(By.css('.pfng-card-title a[href]')).length;
@@ -74,14 +74,14 @@ describe('Info Status Card Component - ', () => {
 
   it('should not have a link present in the title', () => {
     cardConfig.href = null;
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let numTitleLinks = fixture.debugElement.queryAll(By.css('.pfng-card-title a')).length;
     expect(numTitleLinks).toBe(0);
   });
 
   it('should set three info elements', () => {
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let numInfoElements = fixture.debugElement.queryAll(By.css('.pfng-card-info-item')).length;
     expect(numInfoElements).toBe(4);
@@ -89,21 +89,21 @@ describe('Info Status Card Component - ', () => {
 
   it('should show the top border', () => {
     cardConfig.showTopBorder = true;
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let hasAccentedClass = fixture.debugElement.queryAll(By.css('.card-pf.card-pf-accented')).length;
     expect(hasAccentedClass).toBe(1);
   });
 
   it('should hide the top border by default', () => {
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let hasAccentedClass = fixture.debugElement.queryAll(By.css('.card-pf.card-pf-accented')).length;
     expect(hasAccentedClass).toBe(0);
   });
 
   it('should not have an icon image by default', () => {
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let hasIconImg = fixture.debugElement.queryAll(By.css('.info-img')).length;
     expect(hasIconImg).toBe(0);
@@ -111,7 +111,7 @@ describe('Info Status Card Component - ', () => {
 
   it('should set the icon image', () => {
     cardConfig.iconImageSrc = '//www.patternfly.org/assets/img/redhat.svg',
-    Object.assign(infoCard, cardConfig);
+    (<any>Object).assign(infoCard, cardConfig);
     fixture.detectChanges();
     let hasIconImg = fixture.debugElement.queryAll(By.css('.pfng-card-info-image .info-img')).length;
     expect(hasIconImg).toBe(1);

--- a/src/app/filter/examples/filter-save-example.component.ts
+++ b/src/app/filter/examples/filter-save-example.component.ts
@@ -28,7 +28,7 @@ export class FilterSaveExampleComponent implements OnInit {
   filtersText: string = '';
   monthQueries: any[];
   monthQueriesFixed: any[];
-  savedFilters: Map<string, Filter[]>;
+  savedFilters: any = {};
   savedQueries: FilterQuery[];
   separator: Object;
   weekDayQueries: any[];
@@ -37,8 +37,6 @@ export class FilterSaveExampleComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.savedFilters = new Map<string, Filter[]>();
-
     this.allItems = [{
       name: 'Fred Flintstone',
       address: '20 Dinosaur Way, Bedrock, Washingstone',
@@ -223,12 +221,12 @@ export class FilterSaveExampleComponent implements OnInit {
 
       // Flatten saved filters
       if (appliedFilter.field.id === 'saved') {
-        this.savedFilters.get(appliedFilter.value).forEach((filter) => {
+        for (const filter of this.savedFilters[appliedFilter.value]) {
           // Prune duplicates
           if (!this.filterExists(filters, filter)) {
             filters.push(filter);
           }
-        });
+        }
       } else {
         // Prune duplicates
         if (!this.filterExists(filters, appliedFilter)) {
@@ -256,12 +254,12 @@ export class FilterSaveExampleComponent implements OnInit {
         ];
       } else if (field.id === 'saved') {
         field.queries = [];
-        this.savedFilters.forEach((value, key, map) => {
+        for (const key of Object.keys(this.savedFilters)) {
           field.queries.push({
             showDelete: true,
             value: key
           });
-        });
+        }
       }
     });
   }
@@ -316,12 +314,12 @@ export class FilterSaveExampleComponent implements OnInit {
       ];
     } else if (this.filterConfig.fields[index].id === 'saved') {
       let queries: FilterQuery[] = [];
-      this.savedFilters.forEach((value, key, map) => {
+      for (const key of Object.keys(this.savedFilters)) {
         queries.push({
           showDelete: true,
           value: key
         });
-      });
+      }
       this.filterConfig.fields[index].queries = [
         ...queries.filter((item: any) => {
           if (item.value) {
@@ -347,9 +345,9 @@ export class FilterSaveExampleComponent implements OnInit {
 
   // Delete saved filter
   deleteSavedFilter($event: FilterEvent): void {
-    this.savedFilters.delete($event.value); // Delete saved filter
+    delete this.savedFilters[$event.value]; // Delete saved filter
     this.filterFieldSelected($event); // Refresh queries
-    if (this.savedFilters.size === 0) {
+    if (Object.keys(this.savedFilters).length === 0) {
       this.filter.resetCurrentField(); // Reset
     }
   }
@@ -368,8 +366,8 @@ export class FilterSaveExampleComponent implements OnInit {
     } as Filter;
 
     // Load filters
-    this.savedFilters.set('Test1', [filter1]); // Filter values matching February
-    this.savedFilters.set('Test2', [filter1, filter2]); // Filter values matching February and Sunday
+    this.savedFilters['Test1'] = [filter1]; // Filter values matching February
+    this.savedFilters['Test2'] = [filter1, filter2]; // Filter values matching February and Sunday
     this.filterFieldSelected(null); // Refresh queries
   }
 
@@ -379,14 +377,14 @@ export class FilterSaveExampleComponent implements OnInit {
     $event.appliedFilters.forEach((filter) => {
       // Flatten saved filters
       if (filter.field.id === 'saved') {
-        this.savedFilters.get(filter.value).forEach((item) => {
+        for (const item of this.savedFilters[filter.value]) {
           filters.push(item);
-        });
+        }
       } else {
         filters.push(filter);
       }
     });
-    this.savedFilters.set($event.value, filters);
+    this.savedFilters[$event.value] = filters;
     this.filterFieldSelected($event); // Refresh queries
   }
 }

--- a/src/app/list/tree-list/examples/tree-list-basic-example.component.ts
+++ b/src/app/list/tree-list/examples/tree-list-basic-example.component.ts
@@ -285,9 +285,9 @@ export class TreeListBasicExampleComponent implements OnInit {
   }
 
   lazyLoadChildren(node: TreeNode): any {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: any, reject: any) => {
       setTimeout(() => resolve(this.lazyChild.map((c) => {
-        return Object.assign({}, c, {
+        return (<any>Object).assign({}, c, {
           address: node.level + ' Street',
           name: 'Lazy child: ' + node.level,
           hasChildren: node.level < 5,

--- a/src/app/wizard/examples/wizard-basic-example.component.ts
+++ b/src/app/wizard/examples/wizard-basic-example.component.ts
@@ -140,9 +140,9 @@ export class WizardBasicExampleComponent implements OnInit {
 
   stepChanged($event: WizardEvent) {
     let flatSteps = flattenWizardSteps(this.wizard);
-    let currentStep = flatSteps.find(step => step.config.id === $event.step.config.id);
-    if (currentStep) {
-      currentStep.config.nextEnabled = true;
+    let currentStep = flatSteps.filter(step => step.config.id === $event.step.config.id);
+    if (currentStep && currentStep.length > 0) {
+      currentStep[0].config.nextEnabled = true;
     }
     if ($event.step.config.id === 'step1a') {
       this.updateName();

--- a/src/app/wizard/wizard-step.component.ts
+++ b/src/app/wizard/wizard-step.component.ts
@@ -126,9 +126,9 @@ export class WizardStepComponent extends WizardBase implements OnInit, WizardSte
   get nextEnabled() {
     let enabled = this.config.nextEnabled;
     if (this.hasSubsteps) {
-      let selectedSubstep = this.getEnabledSteps().find(step => step.selected);
-      if (selectedSubstep) {
-        enabled = selectedSubstep.config.nextEnabled;
+      let selectedSubstep = this.getEnabledSteps().filter(step => step.selected);
+      if (selectedSubstep && selectedSubstep.length > 0) {
+        enabled = selectedSubstep[0].config.nextEnabled;
       }
     }
     return enabled;
@@ -142,9 +142,9 @@ export class WizardStepComponent extends WizardBase implements OnInit, WizardSte
   get previousEnabled() {
     let enabled = this.config.previousEnabled;
     if (this.hasSubsteps) {
-      let selectedSubstep = this.getEnabledSteps().find(step => step.selected);
-      if (selectedSubstep) {
-        enabled = selectedSubstep.config.previousEnabled;
+      let selectedSubstep = this.getEnabledSteps().filter(step => step.selected);
+      if (selectedSubstep && selectedSubstep.length > 0) {
+        enabled = selectedSubstep[0].config.previousEnabled;
       }
     }
     return enabled;


### PR DESCRIPTION
Clean up build errors by replacing es6 code (Map, find, etc.) with es5 compatible code.

```
Error: /Users/dlabrecq/Work/patternfly/repos/patternfly-ng/src/app/card/info-status-card/info-status-card.component.spec.ts(114)
 Property 'assign' does not exist on type 'ObjectConstructor'.
Error: /Users/dlabrecq/Work/patternfly/repos/patternfly-ng/src/app/filter/examples/filter-save-example.component.ts(39)
 'Map' only refers to a type, but is being used as a value here.
Error: /Users/dlabrecq/Work/patternfly/repos/patternfly-ng/src/app/filter/examples/filter-save-example.component.ts(225)
 Property 'get' does not exist on type 'Map<string, Filter[]>'.
Error: /Users/dlabrecq/Work/patternfly/repos/patternfly-ng/src/app/wizard/examples/wizard-basic-example.component.ts(141)
 Property 'find' does not exist on type 'WizardStep[]'.
...
```

https://rawgit.com/dlabrecq/patternfly-ng/es5-errors-dist/dist-demo/#/filters