### PR TITLE
Simplify pagination list example

### DIFF
--- a/src/app/pagination/examples/pagination-list-example.component.ts
+++ b/src/app/pagination/examples/pagination-list-example.component.ts
@@ -4,8 +4,6 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { cloneDeep, isEqual } from 'lodash';
-
 import { Action } from '../../action/action';
 import { ActionConfig } from '../../action/action-config';
 import { ListEvent } from '../../list/list-event';
@@ -19,15 +17,12 @@ import { PaginationEvent } from '../pagination-event';
   templateUrl: './pagination-list-example.component.html'
 })
 export class PaginationListExampleComponent implements OnInit {
+  actionConfig: ActionConfig;
   actionsText: string = '';
   allItems: any[];
   items: any[];
-  itemsAvailable: boolean = true;
   listConfig: ListConfig;
   paginationConfig: PaginationConfig;
-  actionConfig: ActionConfig;
-  prevConfig: PaginationConfig;
-
 
   constructor() {
   }
@@ -161,23 +156,7 @@ export class PaginationListExampleComponent implements OnInit {
       totalItems: this.allItems.length
     } as PaginationConfig;
 
-    this.items = cloneDeep(this.allItems.slice((this.paginationConfig.pageNumber - 1) * this.paginationConfig.pageSize,
-      this.paginationConfig.totalItems).slice(0, this.paginationConfig.pageSize));
-  }
-
-  ngDoCheck(): void {
-    if (!isEqual(this.paginationConfig, this.prevConfig)) {
-      this.checkPaginationConfig();
-    }
-  }
-
-  /**
-   * Check if Pagination config is changed
-   */
-  checkPaginationConfig() {
-    this.items = cloneDeep(this.allItems.slice((this.paginationConfig.pageNumber - 1) * this.paginationConfig.pageSize,
-      this.paginationConfig.totalItems).slice(0, this.paginationConfig.pageSize));
-    this.prevConfig = cloneDeep(this.paginationConfig);
+    this.updateItems();
   }
 
   // Actions
@@ -199,15 +178,18 @@ export class PaginationListExampleComponent implements OnInit {
 
   handlePageSize($event: PaginationEvent) {
     this.actionsText = 'Page Size: ' + $event.pageSize + ' Selected' + '\n' + this.actionsText;
+    this.updateItems();
   }
 
   handlePageNumber($event: PaginationEvent) {
     this.actionsText = 'Page Number: ' + $event.pageNumber + ' Selected' + '\n' + this.actionsText;
+    this.updateItems();
   }
 
-  // Row selection
+  // Pagination
 
-  updateItemsAvailable(): void {
-    this.items = (this.itemsAvailable) ? cloneDeep(this.allItems) : [];
+  updateItems() {
+    this.items = this.allItems.slice((this.paginationConfig.pageNumber - 1) * this.paginationConfig.pageSize,
+      this.paginationConfig.totalItems).slice(0, this.paginationConfig.pageSize);
   }
 }


### PR DESCRIPTION
Simplify pagination list example.

Currently, the example is maintaining a cloned prevConfig object which is compared every time ngDoCheck is called, then the checkPaginationConfig method clones the list of items twice. Instead, we can simply update the paginated list of items when the PaginationEvent is emitted.

https://rawgit.com/dlabrecq/patternfly-ng/pagination-dist/dist-demo/#/pagination