### PR TITLE
Sparkline and donut chart clean up

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,8 +25,10 @@ export { ChartConfig } from './src/app/chart/chart-config';
 export { ChartDefaults } from './src/app/chart/chart.defaults';
 export { ChartBase } from './src/app/chart/chart.base';
 export { ChartModule } from './src/app/chart/chart.module';
+export { DonutConfig } from './src/app/chart/donut/donut-config';
 export { SparklineComponent } from './src/app/chart/sparkline/sparkline.component';
 export { SparklineConfig } from './src/app/chart/sparkline/sparkline-config';
+export { SparklineData } from './src/app/chart/sparkline/sparkline-data';
 
 // EmptyState
 export { EmptyStateComponent } from './src/app/empty-state/empty-state.component';

--- a/src/app/card/basic-card/examples/card-basic-example.component.ts
+++ b/src/app/card/basic-card/examples/card-basic-example.component.ts
@@ -7,6 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
+import { SparklineConfig } from '../../../chart/sparkline/sparkline-config';
+import { SparklineData } from '../../../chart/sparkline/sparkline-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -16,12 +18,12 @@ import { CardFilter } from '../../card-filter/card-filter';
 export class CardBasicExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfig: any = {
+  chartConfig: SparklineConfig = {
     chartHeight: 60,
     chartId: 'exampleSparkline',
     tooltipType: 'default'
   };
-  chartData: any = {
+  chartData: SparklineData = {
     dataAvailable: true,
     total: 100,
     xData: this.chartDates,

--- a/src/app/card/basic-card/examples/card-trend-example.component.ts
+++ b/src/app/card/basic-card/examples/card-trend-example.component.ts
@@ -7,6 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
+import { SparklineConfig } from '../../../chart/sparkline/sparkline-config';
+import { SparklineData } from '../../../chart/sparkline/sparkline-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -16,12 +18,12 @@ import { CardFilter } from '../../card-filter/card-filter';
 export class CardTrendExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfigVirtual: any = {
+  chartConfigVirtual: SparklineConfig = {
     chartHeight: 60,
     chartId: 'virtualTrendsChart',
     tooltipType: 'default'
   };
-  chartDataVirtual: any = {
+  chartDataVirtual: SparklineData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -29,12 +31,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '90', '20', '30', '20', '20', '10', '14', '20', '25',
       '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
   };
-  chartConfigPhysical: any = {
+  chartConfigPhysical: SparklineConfig = {
     chartHeight: 60,
     chartId: 'physicalTrendsChart',
     tooltipType: 'default'
   };
-  chartDataPhysical: any = {
+  chartDataPhysical: SparklineData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -42,12 +44,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '20', '20', '35', '20', '20', '87', '14', '20', '25',
       '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
   };
-  chartConfigMemory: any = {
+  chartConfigMemory: SparklineConfig = {
     chartHeight: 60,
     chartId: 'memoryTrendsChart',
     tooltipType: 'default'
   };
-  chartDataMemory: any = {
+  chartDataMemory: SparklineData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,

--- a/src/app/chart/chart-config.ts
+++ b/src/app/chart/chart-config.ts
@@ -1,20 +1,16 @@
 /**
- * A base config containing properties for the  chart
+ * A base config containing properties for charts
  */
 export abstract class ChartConfig {
-
   /**
    * The id of the chart used in the markup
    */
   chartId?: string;
 
   /**
-   * An array of untyped data
+   * C3 inherited configuration for data
+   *
+   * See: http://c3js.org/reference.html#data
    */
-  data: any;
-
-  /**
-   * C3 configuration id for element to bind to
-   */
-  bindto?: string;
+  data?: any;
 }

--- a/src/app/chart/chart.base.ts
+++ b/src/app/chart/chart.base.ts
@@ -1,56 +1,44 @@
-import { EventEmitter, Input, Output } from '@angular/core';
-
-import * as c3 from 'c3';
+import { EventEmitter, Output } from '@angular/core';
 
 import { cloneDeep } from 'lodash';
+import * as c3 from 'c3';
 
 import { ChartConfig } from './chart-config';
 
 export abstract class ChartBase {
-  /**
-   * Chart configuration object with data
-   */
-  @Input() public config: ChartConfig;
-
   /**
    * Event emitted with the chart reference after load is complete
    * @type {EventEmitter}
    */
   @Output() chartLoaded: EventEmitter<any> = new EventEmitter();
 
-  /**
-   * Stored previous config to check for any changes
-   */
-  protected prevConfig: ChartConfig;
-
-  // store the chart object
+  // Store the chart object
   private chart: any;
 
-  constructor() {
-  }
+  /**
+   * Default constructor
+   */
+  constructor() {}
 
   /**
    * Protected method called when configuration or data changes by any class that inherits from this
-   * @param chartId
-   * @param reload
+   *
+   * @param config The config for the c3 chart
+   * @param reload True to reload
    */
-  protected generateChart(chartId: string, reload?: boolean): void {
+  protected generateChart(config: ChartConfig, reload?: boolean): void {
     setTimeout(() => {
-      let c3Config = this.config;
-      if (c3Config) {
-        c3Config.bindto = '#' + chartId;
-        // always re-generate donut pct chart because it's colors
-        // change based on data and thresholds
-        if (!this.chart || reload || chartId.indexOf('donutPctChart') > -1) {
-          this.chart = c3.generate(c3Config);
-        } else {
-          // if chart is already created, then we only need to re-load data
-          this.chart.load(this.config.data);
-        }
+      let c3Config: any = cloneDeep(config);
+      c3Config.bindto = '#' + config.chartId;
 
-        this.chartLoaded.emit(this.chart);
-        this.prevConfig = cloneDeep(this.config);
+      // Note: Always re-generate donut pct chart because it's colors change based on data and thresholds
+      if (this.chart === undefined || reload === true) {
+        this.chart = c3.generate(c3Config);
+      } else {
+        // if chart is already created, then we only need to re-load data
+        this.chart.load(c3Config.data);
       }
+      this.chartLoaded.emit(this.chart);
     });
   }
 }

--- a/src/app/chart/chart.module.ts
+++ b/src/app/chart/chart.module.ts
@@ -4,7 +4,17 @@ import { NgModule } from '@angular/core';
 
 import { ChartDefaults } from './chart.defaults';
 import { DonutComponent } from './donut/donut.component';
+import { DonutConfig } from './donut/donut-config';
 import { SparklineComponent } from './sparkline/sparkline.component';
+import { SparklineConfig } from './sparkline/sparkline-config';
+import { SparklineData } from './sparkline/sparkline-data';
+import { WindowReference } from '../utilities/window.reference';
+
+export {
+  DonutConfig,
+  SparklineConfig,
+  SparklineData
+};
 
 @NgModule({
   imports: [
@@ -13,6 +23,6 @@ import { SparklineComponent } from './sparkline/sparkline.component';
   ],
   declarations: [SparklineComponent, DonutComponent],
   exports: [SparklineComponent, DonutComponent],
-  providers: [ChartDefaults]
+  providers: [ChartDefaults, WindowReference]
 })
 export class ChartModule {}

--- a/src/app/chart/donut/donut-config.ts
+++ b/src/app/chart/donut/donut-config.ts
@@ -3,16 +3,10 @@ import { ChartConfig } from '../chart-config';
  * A config containing properties for the sparkline chart
  */
 export class DonutConfig extends ChartConfig {
-
   /**
    * Text for the donut chart center label (optional)
    */
   centerLabel?: any;
-
-  /**
-   * An optional function to handle when donut is clicked
-   */
-  onClickFn?: any;
 
   /**
    * The height of the donut chart (optional)
@@ -21,24 +15,28 @@ export class DonutConfig extends ChartConfig {
 
   /**
    * C3 inherited configuration for colors
-   * An object with key-value pairs of data name and color, e.g.
+   *
    * colors : {
    *   Cats: '#0088ce',
    *   Hamsters: '#3f9c35',
    * }
-   *
    */
   colors?: any;
-
-  /**
-   * C3 inherited configuration for size
-   */
-  size?: any;
 
   /**
    * C3 inherited donut configuration
    */
   donut?: any;
+
+  /**
+   * C3 inherited legend configuration
+   */
+  legend?: any;
+
+  /**
+   * C3 inherited configuration for size
+   */
+  size?: any;
 
   /**
    * C3 inherited configuration for tooltip

--- a/src/app/chart/donut/donut.component.spec.ts
+++ b/src/app/chart/donut/donut.component.spec.ts
@@ -7,56 +7,54 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 
+import { ChartDefaults } from '../chart.defaults';
 import { DonutConfig } from './donut-config';
 import { DonutComponent } from './donut.component';
-import { ChartDefaults } from '../chart.defaults';
+import { WindowReference } from '../../utilities/window.reference';
 
 describe('Component: donut chart', () => {
-
   let comp: DonutComponent;
   let fixture: ComponentFixture<DonutComponent>;
 
   let config: DonutConfig;
-  let data: any;
+  let chartData: any[];
 
   beforeEach(() => {
-    config = {
-      chartId: 'testDonutChart',
-      onClickFn: function(d: any, e: any) {
-      },
-      data: {},
-      donut: {
-        title: 'Animals'
-      }
-    };
-    data = [
+    chartData = [
       ['Cats', 2],
       ['Hamsters', 2],
       ['Dogs', 2]
     ];
+    config = {
+      chartId: 'testChart',
+      data: {
+        onclick: function(d: any, e: any) {}
+      },
+      donut: {
+        title: 'Animals'
+      }
+    };
   });
-
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, FormsModule],
       declarations: [DonutComponent],
-      providers: [ChartDefaults]
+      providers: [ChartDefaults, WindowReference]
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(DonutComponent);
         comp = fixture.componentInstance;
         comp.config = config;
-        comp.chartData = data;
+        comp.chartData = chartData;
         fixture.detectChanges();
       });
   }));
 
   it('should set chart id', () => {
-    expect(comp.config.chartId).toContain('testDonutChart');
+    expect(comp.config.chartId).toContain('testChart');
   });
-
 
   it('should allow attribute specification of chart height', () => {
     config.chartHeight = 120;
@@ -86,7 +84,7 @@ describe('Component: donut chart', () => {
     expect(comp.config.data.columns[0][0]).toBe('Cats');
     expect(comp.config.data.columns[0][1]).toBe(2);
 
-    data[0][1] = 3;
+    chartData[0][1] = 3;
     fixture.detectChanges();
 
     expect(comp.config.data.columns[0][1]).toBe(3);

--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -1,79 +1,145 @@
-import { Component, DoCheck, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  DoCheck,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import * as d3 from 'd3';
+import { cloneDeep, defaultsDeep, isEqual, merge, uniqueId } from 'lodash';
 
-import { cloneDeep, defaults, isEqual, merge, uniqueId } from 'lodash';
+import * as d3 from 'd3';
 
 import { ChartDefaults } from '../chart.defaults';
 import { ChartBase } from '../chart.base';
 import { DonutConfig } from './donut-config';
+import { WindowReference } from '../../utilities/window.reference';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'pfng-chart-donut',
   templateUrl: './donut.component.html'
 })
-export class DonutComponent extends ChartBase implements DoCheck, OnInit {
+export class DonutComponent extends ChartBase implements DoCheck, OnDestroy, OnInit {
+  /**
+   * An array containing key value pairs:
+   *
+   * key - string representing an arc within the donut chart
+   * value - number representing the value of the arc
+   */
+  @Input() chartData: any[];
 
-  @Input() chartData: any;
+  /**
+   * Configuration object containing details about how to render the chart
+   */
   @Input() config: DonutConfig;
 
-  private prevChartData: any;
-
+  private defaultConfig: DonutConfig;
+  private prevChartData: any[];
+  private prevConfig: DonutConfig;
   private subscriptions: Subscription[] = [];
 
   /**
    * Default constructor
    * @param chartDefaults
    */
-  constructor(private chartDefaults: ChartDefaults) {
+  constructor(private chartDefaults: ChartDefaults, private windowRef: WindowReference) {
     super();
-  }
-
-  ngOnInit(): void {
-    if (!this.config.chartId) {
-      throw new Error('DonutComponent: config must have string property chartId');
-    }
-    this.config.chartId = uniqueId(this.config.chartId);
-
     this.subscriptions.push(this.chartLoaded.subscribe({
       next: (chart: any) => {
         this.chartAvailable(chart);
       }
     }));
-
-    this.setupConfigDefaults();
   }
 
+  /**
+   * Setup component configuration upon initialization
+   */
+  ngOnInit(): void {
+    this.setupConfigDefaults();
+    this.setupConfig();
+    this.generateChart(this.config);
+  }
+
+  /**
+   * Check if the component config has changed
+   */
   ngDoCheck(): void {
-    if (!isEqual(this.config, this.prevConfig)) {
-      this.updateConfig();
-      this.generateChart(this.config.chartId, true);
-    } else if (!isEqual(this.chartData, this.prevChartData)) {
-      this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
-      this.generateChart(this.config.chartId, false);
-      this.prevChartData = cloneDeep(this.chartData);
+    if (!isEqual(this.config, this.prevConfig) || !isEqual(this.chartData, this.prevChartData)) {
+      this.setupConfig();
+      this.generateChart(this.config, true);
     }
   }
 
+  /**
+   * Clean up subscriptions
+   */
   ngOnDestroy(): void {
     this.subscriptions.forEach(sub => sub.unsubscribe);
   }
 
-  // Public for testing
-  public getCenterLabelText(): any {
+  /**
+   * Set up default config
+   */
+  protected setupConfig(): void {
+    if (this.config !== undefined) {
+      defaultsDeep(this.config, this.defaultConfig);
+    } else {
+      this.config = cloneDeep(this.defaultConfig);
+    }
+
+    if (this.config.chartHeight !== undefined) {
+      this.config.size.height = this.config.chartHeight;
+    }
+    this.config.data = merge(this.config.data, this.getChartData());
+    this.prevConfig = cloneDeep(this.config);
+    this.prevChartData = cloneDeep(this.chartData);
+  }
+
+  /**
+   * Set up default config
+   */
+  protected setupConfigDefaults(): void {
+    this.defaultConfig = this.chartDefaults.getDefaultDonutConfig();
+    this.defaultConfig.chartId = uniqueId();
+    this.defaultConfig.data = {
+      type: 'donut',
+      order: null
+    };
+    this.defaultConfig.donut = this.chartDefaults.getDefaultDonut();
+    this.defaultConfig.tooltip = { contents: (this.windowRef.nativeWindow).patternfly.pfDonutTooltipContents };
+  }
+
+  /**
+   * Convert chartData to C3 data property
+   */
+  protected getChartData(): any {
+    return {
+      columns: this.chartData,
+      colors: this.config.colors
+    };
+  }
+
+  /**
+   * Returns an object containing center label properties
+   * @returns {any}
+   */
+  getCenterLabelText(): any {
+    // Public for testing
     let centerLabelText = {
       bigText: this.getTotal(),
       smText: this.config.donut.title
     };
-
     if (this.config.centerLabel) {
       centerLabelText.bigText = this.config.centerLabel;
       centerLabelText.smText = '';
     }
-
     return centerLabelText;
   }
+
+  // Private
 
   private chartAvailable(chart: any): void {
     this.setupDonutChartTitle(chart);
@@ -81,24 +147,25 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
 
   private getTotal(): number {
     let total = 0;
-    this.chartData.forEach((element: any) => {
-      if (!isNaN(element[1])) {
-        total += Number(element[1]);
-      }
-    });
-
+    if (this.config.data !== undefined && this.config.data.columns !== undefined) {
+      this.config.data.columns.forEach((element: any) => {
+        if (!isNaN(element[1])) {
+          total += Number(element[1]);
+        }
+      });
+    }
     return total;
   }
 
   private setupDonutChartTitle(chart: any): void {
     let donutChartTitle, centerLabelText;
 
-    if (!chart) {
+    if (chart === undefined) {
       return;
     }
 
     donutChartTitle = d3.select(chart.element).select('text.c3-chart-arcs-title');
-    if (!donutChartTitle) {
+    if (donutChartTitle === undefined) {
       return;
     }
 
@@ -113,36 +180,5 @@ export class DonutComponent extends ChartBase implements DoCheck, OnInit {
       donutChartTitle.insert('tspan', null).text(centerLabelText.smText).
         classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
     }
-  }
-
-  private getDonutData(chartData: any): any {
-    return {
-      type: 'donut',
-      columns: this.chartData,
-      order: null,
-      colors: this.config.colors
-    };
-  }
-
-  private setupConfigDefaults(): void {
-    let defaultConfig = this.chartDefaults.getDefaultDonutConfig();
-    let defaultDonut = this.chartDefaults.getDefaultDonut();
-
-    defaults(this.config, defaultConfig);
-    defaults(this.config.donut, defaultDonut);
-  }
-
-  private updateConfig(): void {
-    this.config.data = merge(this.config.data, this.getDonutData(this.chartData));
-
-    if (this.config.chartHeight) {
-      this.config.size.height = this.config.chartHeight;
-    }
-
-    if (this.config.onClickFn) {
-      this.config.data.onclick = this.config.onClickFn;
-    }
-
-    this.config.tooltip = { contents: (window as any).patternfly.pfDonutTooltipContents };
   }
 }

--- a/src/app/chart/donut/examples/donut-basic-example.component.html
+++ b/src/app/chart/donut/examples/donut-basic-example.component.html
@@ -1,0 +1,37 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <label>Donut Chart</label>
+    </div>
+    <div class="col-md-6 text-center">
+      <label>Small Donut Chart</label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [chartData]="chartData" [config]="largeConfig"></pfng-chart-donut>
+    </div>
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [chartData]="chartData" [config]="smallConfig"></pfng-chart-donut>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="api">
+        <iframe class="demoframe" src="docs/classes/donutcomponent.html"></iframe>
+      </tab>
+      <tab heading="html">
+        <include-content src="src/app/chart/donut/examples/donut-basic-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="src/app/chart/donut/examples/donut-basic-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/chart/donut/examples/donut-basic-example.component.ts
+++ b/src/app/chart/donut/examples/donut-basic-example.component.ts
@@ -1,0 +1,60 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { cloneDeep } from 'lodash';
+
+import { DonutConfig } from '../donut-config';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'donut-basic-example',
+  templateUrl: './donut-basic-example.component.html'
+})
+export class DonutBasicExampleComponent implements OnInit {
+  chartData: any[] = [
+    ['Cats', 2],
+    ['Hamsters', 1],
+    ['Fish', 3],
+    ['Dogs', 2]
+  ];
+
+  largeConfig: DonutConfig = {
+    chartId: 'exampleDonut',
+    colors: {
+      Cats: '#0088ce',     // blue
+      Hamsters: '#3f9c35', // green
+      Fish: '#ec7a08',     // orange
+      Dogs: '#cc0000'      // red
+    },
+    data: {
+      onclick: (data: any, element: any) => {
+        alert('You clicked on donut arc: ' + data.id);
+      }
+    },
+    donut: {
+      title: 'Animals'
+    },
+    legend: {
+      show: true
+    }
+  };
+
+  smallConfig: DonutConfig;
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    this.smallConfig = cloneDeep(this.largeConfig);
+    this.smallConfig.chartId = 'exampleDonut2';
+    this.smallConfig.legend = {
+      show: true,
+      position: 'right'
+    };
+    this.smallConfig.centerLabel = 'Pets';
+    this.smallConfig.chartHeight = 120;
+  }
+}

--- a/src/app/chart/donut/examples/donut-dynamic-example.component.html
+++ b/src/app/chart/donut/examples/donut-dynamic-example.component.html
@@ -1,0 +1,37 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <label>Donut Chart</label>
+    </div>
+    <div class="col-md-6 text-center">
+      <label>Small Donut Chart</label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [chartData]="chartData" [config]="largeConfig"></pfng-chart-donut>
+    </div>
+    <div class="col-md-6 text-center">
+      <pfng-chart-donut [chartData]="chartData" [config]="smallConfig"></pfng-chart-donut>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="api">
+        <iframe class="demoframe" src="docs/classes/donutcomponent.html"></iframe>
+      </tab>
+      <tab heading="html">
+        <include-content src="src/app/chart/donut/examples/donut-dynamic-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="src/app/chart/donut/examples/donut-dynamic-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/chart/donut/examples/donut-dynamic-example.component.ts
+++ b/src/app/chart/donut/examples/donut-dynamic-example.component.ts
@@ -1,0 +1,81 @@
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+
+import { cloneDeep } from 'lodash';
+
+import { DonutConfig } from '../donut-config';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'donut-dynamic-example',
+  templateUrl: './donut-dynamic-example.component.html'
+})
+export class DonutDynamicExampleComponent implements OnDestroy, OnInit {
+  chartData: any[] = [
+    ['Cats', 2],
+    ['Hamsters', 1],
+    ['Fish', 3],
+    ['Dogs', 2]
+  ];
+
+  largeConfig: DonutConfig = {
+    chartId: 'exampleDonut',
+    colors: {
+      Cats: '#0088ce',     // blue
+      Hamsters: '#3f9c35', // green
+      Fish: '#ec7a08',     // orange
+      Dogs: '#cc0000'      // red
+    },
+    data: {
+      onclick: (data: any, element: any) => {
+        alert('You clicked on donut arc: ' + data.id);
+      }
+    },
+    donut: {
+      title: 'Animals'
+    },
+    legend: {
+      show: true
+    }
+  };
+
+  smallConfig: DonutConfig;
+  subscriptions: Subscription[] = [];
+
+  constructor() {
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => sub.unsubscribe);
+  }
+
+  ngOnInit(): void {
+    this.smallConfig = cloneDeep(this.largeConfig);
+    this.smallConfig.chartId = 'exampleDonut2';
+    this.smallConfig.legend = {
+      show: true,
+      position: 'right'
+    };
+    this.smallConfig.centerLabel = 'Pets';
+    this.smallConfig.chartHeight = 120;
+
+    this.subscriptions.push(Observable
+      .timer(0, 1000)
+      .map(() => Math.floor(Math.random() * 5) + 1)
+      .subscribe(val => {
+        this.chartData[0][1] = val;
+      }));
+
+    this.subscriptions.push(Observable
+      .timer(0, 5000)
+      .map(() => Math.floor(Math.random() * 100) + 100)
+      .subscribe(val => {
+        this.smallConfig.chartHeight = val;
+      }));
+  }
+}

--- a/src/app/chart/donut/examples/donut-example.component.html
+++ b/src/app/chart/donut/examples/donut-example.component.html
@@ -1,44 +1,16 @@
 <div class="padding-15">
-  <div class="row padding-bottom-15">
+  <div class="row">
     <div class="col-xs-12">
-      <h4>Donut Chart Example</h4>
+      <h4>Donut Component Example</h4>
       <hr/>
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-6 text-center">
-      <label>Donut Chart</label>
-    </div>
-    <div class="col-md-6 text-center">
-      <label>Small Donut Chart</label>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6 text-center">
-      <pfng-chart-donut [config]="config" [chartData]="data"></pfng-chart-donut>
-    </div>
-    <div class="col-md-6 text-center">
-      <pfng-chart-donut [config]="config2" [chartData]="data"></pfng-chart-donut>
-    </div>
-  </div>
-
-  <div class="row padding-bottom-15 padding-top-15">
-    <div class="col-xs-12">
-      <h4>Code</h4>
-      <hr/>
-    </div>
-  </div>
-  <div>
-    <tabset>
-      <tab heading="api">
-        <iframe class="demoframe" src="docs/classes/donutcomponent.html"></iframe>
-      </tab>
-      <tab heading="html">
-        <include-content src="src/app/chart/donut/examples/donut-example.component.html"></include-content>
-      </tab>
-      <tab heading="typescript">
-        <include-content src="src/app/chart/donut/examples/donut-example.component.ts"></include-content>
-      </tab>
-    </tabset>
-  </div>
+  <tabset>
+    <tab heading="Basic" (select)="tabSelected($event)">
+      <donut-basic-example *ngIf="activeTab === 'Basic' || activeTab === ''"></donut-basic-example>
+    </tab>
+    <tab heading="Dynamic" (select)="tabSelected($event)">
+      <donut-dynamic-example *ngIf="activeTab === 'Dynamic'"></donut-dynamic-example>
+    </tab>
+  </tabset>
 </div>

--- a/src/app/chart/donut/examples/donut-example.component.ts
+++ b/src/app/chart/donut/examples/donut-example.component.ts
@@ -3,9 +3,8 @@ import {
   OnInit,
   ViewEncapsulation
 } from '@angular/core';
-import { Observable } from 'rxjs';
 
-import { cloneDeep } from 'lodash';
+import { TabDirective } from 'ngx-bootstrap/tabs';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -13,57 +12,20 @@ import { cloneDeep } from 'lodash';
   templateUrl: './donut-example.component.html'
 })
 export class DonutExampleComponent implements OnInit {
-  public config: any = {
-    chartId: 'exampleDonut',
-    colors: {
-      Cats: '#0088ce',     // blue
-      Hamsters: '#3f9c35', // green
-      Fish: '#ec7a08',     // orange
-      Dogs: '#cc0000'      // red
-    },
-    onClickFn: (data: any, element: any) => {
-      alert('You clicked on donut arc: ' + data.id);
-    },
-    donut: {
-      title: 'Animals'
-    },
-    legend: {
-      show: true
-    }
-  };
-
-  public config2: any;
-
-  public data: any = [
-    ['Cats', 2],
-    ['Hamsters', 1],
-    ['Fish', 3],
-    ['Dogs', 2]
-  ];
+  activeTab: string = '';
 
   constructor() {
   }
 
   ngOnInit(): void {
-    this.config2 = cloneDeep(this.config);
-    this.config2.chartId = 'exampleDonut2';
-    this.config2.legend = {
-      show: true,
-      position: 'right'
-    };
-    this.config2.centerLabelFn = () => {
-      return 'Pets';
-    };
-    this.config2.chartHeight = 120;
+  }
 
-    Observable
-      .timer(0, 1000)
-      .map(() => Math.floor(Math.random() * 5) + 1)
-      .subscribe(val => this.data[0][1] = val);
+  ngDoCheck(): void {
+  }
 
-    Observable
-    .timer(0, 5000)
-    .map(() => Math.floor(Math.random() * 100) + 100)
-    .subscribe(val => this.config2.chartHeight = val);
+  // Actions
+
+  tabSelected($event: TabDirective): void {
+    this.activeTab = $event.heading;
   }
 }

--- a/src/app/chart/donut/examples/donut-example.module.ts
+++ b/src/app/chart/donut/examples/donut-example.module.ts
@@ -5,10 +5,12 @@ import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { ChartModule } from '../../chart.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
+import { DonutBasicExampleComponent } from './donut-basic-example.component';
+import { DonutDynamicExampleComponent } from './donut-dynamic-example.component';
 import { DonutExampleComponent } from './donut-example.component';
 
 @NgModule({
-  declarations: [DonutExampleComponent],
+  declarations: [DonutBasicExampleComponent, DonutDynamicExampleComponent, DonutExampleComponent],
   imports: [
     ChartModule,
     CommonModule,

--- a/src/app/chart/sparkline/examples/sparkline-example.component.html
+++ b/src/app/chart/sparkline/examples/sparkline-example.component.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-sm-12">
       <div class="form-group">
-        <pfng-chart-sparkline [config]="config" [chartData]="data" ></pfng-chart-sparkline>
+        <pfng-chart-sparkline [chartData]="chartData" [config]="config"></pfng-chart-sparkline>
       </div>
     </div>
   </div>
@@ -18,7 +18,6 @@
       <hr/>
     </div>
   </div>
-
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-md-12">
       <form role="form">

--- a/src/app/chart/sparkline/examples/sparkline-example.component.ts
+++ b/src/app/chart/sparkline/examples/sparkline-example.component.ts
@@ -4,38 +4,40 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
+import { SparklineConfig } from '../sparkline-config';
+
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'sparkline-example',
   templateUrl: './sparkline-example.component.html'
 })
 export class SparklineExampleComponent implements OnInit {
-  protected dates: any[] = ['dates'];
-  public config: any = {
-    chartId: 'exampleSparkline',
-    tooltipType: 'default'
-  };
-  public data: any = {
+  dates: any[] = ['dates'];
+  chartData: any = {
     dataAvailable: true,
     total: 100,
     xData: this.dates,
     yData: ['used', 10, 20, 30, 20, 30, 10, 14, 20, 25, 68, 54, 56, 78, 56, 67, 88, 76, 65, 87, 76]
+  };
+  config: SparklineConfig = {
+    chartId: 'exampleSparkline',
+    chartHeight: 60,
+    tooltipType: 'default'
   };
 
   constructor() {
   }
 
   ngOnInit(): void {
-    this.config.chartHeight = 60;
     let today = new Date();
-
     for (let d = 20 - 1; d >= 0; d--) {
       this.dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
     }
   }
 
   addDataPoint(): void {
-    this.data.xData.push(new Date(this.data.xData[this.data.xData.length - 1].getTime() + (24 * 60 * 60 * 1000)));
-    this.data.yData.push(Math.round(Math.random() * 100));
+    this.chartData.xData.push(new Date(
+      this.chartData.xData[this.chartData.xData.length - 1].getTime() + (24 * 60 * 60 * 1000)));
+    this.chartData.yData.push(Math.round(Math.random() * 100));
   }
 }

--- a/src/app/chart/sparkline/sparkline-config.ts
+++ b/src/app/chart/sparkline/sparkline-config.ts
@@ -3,16 +3,10 @@ import { ChartConfig } from '../chart-config';
  * A config containing properties for the sparkline chart
  */
 export class SparklineConfig extends ChartConfig {
-
   /**
-   * An optional function for displaying tooltip content
+   * C3 inherited configuration for axis
    */
-  tooltipFn?: any;
-
-  /**
-   * Options include usagePerDay, valuePerDay, percentage or default
-   */
-  tooltipType?: string;
+  axis?: any;
 
   /**
    * The height of the chart
@@ -30,22 +24,26 @@ export class SparklineConfig extends ChartConfig {
   showYAxis?: boolean;
 
   /**
-   * C3 inherited configuration for axis
-   */
-  axis?: any;
-
-  /**
    * C3 inherited configuration for size object
+   *
+   * See: http://c3js.org/reference.html#size
    */
   size?: any;
+
+  /**
+   * C3 inherited configuration for tooltip
+   *
+   * See: http://c3js.org/reference.html#tooltip
+   */
+  tooltip?: any;
+
+  /**
+   * Options include usagePerDay, valuePerDay, percentage or default
+   */
+  tooltipType?: string;
 
   /**
    * The unit of measure for the chart
    */
   units?: string;
-
-  /**
-   * C3 inherited configuration for tooltip
-   */
-  tooltip?: any;
 }

--- a/src/app/chart/sparkline/sparkline-data.ts
+++ b/src/app/chart/sparkline/sparkline-data.ts
@@ -1,0 +1,24 @@
+/**
+ * A base config containing properties for chart data
+ */
+export abstract class SparklineData {
+  /**
+   * True is data is available
+   */
+  dataAvailable?: boolean;
+
+  /**
+   * The Total amount, used when determining percentages
+   */
+  total?: number;
+
+  /**
+   * X values for the data points, first element must be the name of the data
+   */
+  xData?: any[];
+
+  /**
+   * Y Values for the data points, first element must be the name of the data
+   */
+  yData?: any[];
+}

--- a/src/app/chart/sparkline/sparkline.component.html
+++ b/src/app/chart/sparkline/sparkline.component.html
@@ -1,1 +1,1 @@
-<div #chartElement id="{{sparklineChartId}}"></div>
+<div #chartElement id="{{config.chartId}}"></div>

--- a/src/app/chart/sparkline/sparkline.component.spec.ts
+++ b/src/app/chart/sparkline/sparkline.component.spec.ts
@@ -7,39 +7,35 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 
-import { SparklineConfig } from './sparkline-config';
-import { SparklineComponent } from './sparkline.component';
 import { ChartDefaults } from '../chart.defaults';
+import { SparklineComponent } from './sparkline.component';
+import { SparklineConfig } from './sparkline-config';
+import { SparklineData } from './sparkline-data';
 
 describe('Component: sparkline chart', () => {
-
   let comp: SparklineComponent;
   let fixture: ComponentFixture<SparklineComponent>;
 
   let config: SparklineConfig;
-  let data: any;
+  let chartData: SparklineData;
 
   beforeEach(() => {
-    config = {
-      'chartId': 'testSparklineChart',
-      'units': 'MHz',
-      data: {}
-    };
-
     let today = new Date();
     let dates: any = ['dates'];
     for (let d = 20 - 1; d >= 0; d--) {
       dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
     }
-
-    data = {
-      'total': '100',
-      'yData': ['used', '10', '20', '30', '20', '30', '10', '14', '20',
+    chartData = {
+      total: 100,
+      yData: ['used', '10', '20', '30', '20', '30', '10', '14', '20',
         '25', '68', '54', '56', '78', '56', '67', '88', '76', '65', '87', '76'],
-      'xData': dates
+      xData: dates
+    };
+    config = {
+      chartId: 'testChart',
+      units: 'MHz'
     };
   });
-
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -52,16 +48,19 @@ describe('Component: sparkline chart', () => {
         fixture = TestBed.createComponent(SparklineComponent);
         comp = fixture.componentInstance;
         comp.config = config;
-        comp.chartData = data;
+        comp.chartData = chartData;
         fixture.detectChanges();
       });
   }));
 
+  it('should set chart id', () => {
+    expect(comp.config.chartId).toContain('testChart');
+  });
+
   it('should not show axis by default', () => {
-    let elements = fixture.debugElement.queryAll(By.css('#testSparklineChartsparklineChart'));
+    let elements = fixture.debugElement.queryAll(By.css('#testChart'));
     expect(elements.length).toBe(1);
 
-    expect(comp.sparklineChartId).toBe('testSparklineChartsparklineChart');
     expect(comp.config.axis.x.show).toBe(false);
     expect(comp.config.axis.y.show).toBe(false);
   });
@@ -72,7 +71,6 @@ describe('Component: sparkline chart', () => {
 
     fixture.detectChanges();
 
-    expect(comp.sparklineChartId).toBe('testSparklineChartsparklineChart');
     expect(comp.config.axis.x.show).toBe(true);
     expect(comp.config.axis.y.show).toBe(true);
   });
@@ -103,7 +101,6 @@ describe('Component: sparkline chart', () => {
     config.chartHeight = 120;
 
     fixture.detectChanges();
-    expect(comp.sparklineChartId).toBe('testSparklineChartsparklineChart');
     expect(comp.config.size.height).toBe(120);
 
     config.chartHeight = 100;
@@ -122,12 +119,12 @@ describe('Component: sparkline chart', () => {
   it('should update C3 chart data when data changes', () => {
     expect(comp.config.data.x).toBe('dates');
     expect(comp.config.data.columns.length).toBe(2);
-    expect(comp.config.data.columns[0][1].toString()).toBe(data.xData[1].toString());
+    expect(comp.config.data.columns[0][1].toString()).toBe(chartData.xData[1].toString());
     expect(comp.config.data.columns[1][1]).toBe('10');
 
     let now = new Date();
-    data.xData[1] = now;
-    data.yData[1] = '1000';
+    chartData.xData[1] = now;
+    chartData.yData[1] = '1000';
 
     fixture.detectChanges();
 
@@ -142,19 +139,19 @@ describe('Component: sparkline chart', () => {
   });
 
   it('should allow using a tooltip function', () => {
-    let functionCalled = false;
-    let myTooltipFn = function(d) {
-      if (d && d.length === 2) {
-        functionCalled = true;
+    let tooltipCalled = false;
+    let tooltip = {
+      contents: (d: any) => {
+        tooltipCalled = true;
       }
     };
 
-    config.tooltipFn = myTooltipFn;
+    config.tooltip = tooltip;
     fixture.detectChanges();
 
     let dataPoint = [{ value: 0, name: 'used' }, 0];
-    comp.sparklineTooltip().contents(dataPoint);
-    expect(functionCalled).toBe(true);
+    config.tooltip.contents(dataPoint); // TODO - c3 should invoke tooltip
+    expect(tooltipCalled).toBe(true);
   });
 
   it('should allow using C3 chart data formats', () => {
@@ -164,10 +161,10 @@ describe('Component: sparkline chart', () => {
       data: {
         xFormat: '%Y-%m-%d %H:%M:%S',
         x: 'dates',
-        columns: [data.xData, data.yData]
+        columns: [chartData.xData, chartData.yData]
       }
     };
-    data = {
+    chartData = {
       total: 100
     };
 

--- a/src/app/chart/sparkline/sparkline.component.ts
+++ b/src/app/chart/sparkline/sparkline.component.ts
@@ -1,36 +1,40 @@
-import { Component, DoCheck, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  DoCheck,
+  Input,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
 
-import { cloneDeep, defaults, isEqual, merge } from 'lodash';
+import { cloneDeep, defaultsDeep, isEqual, merge, uniqueId } from 'lodash';
 
 import { ChartBase } from '../chart.base';
 import { ChartDefaults } from '../chart.defaults';
 import { SparklineConfig } from './sparkline-config';
+import { SparklineData } from './sparkline-data';
 
 /**
  * Sparkline chart component based on C3
  */
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'pfng-chart-sparkline',
   templateUrl: './sparkline.component.html'
 })
 export class SparklineComponent extends ChartBase implements DoCheck, OnInit {
   /**
-   * Chart data for the chart
+   * Chart data
    */
-  @Input() chartData: any;
+  @Input() chartData: SparklineData;
 
   /**
    * Configuration object containing details about how to render the chart
    */
   @Input() config: SparklineConfig;
 
-  /**
-   * The chart id created during initialization
-   */
-  public sparklineChartId: any;
-
-  private prevChartData: any;
   private defaultConfig: SparklineConfig;
+  private prevChartData: SparklineData;
+  private prevConfig: SparklineConfig;
 
   /**
    * Default constructor
@@ -41,133 +45,60 @@ export class SparklineComponent extends ChartBase implements DoCheck, OnInit {
   }
 
   /**
-   * NgOnInit implementation
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
-    // Create an ID for the chart based on the chartId in the config if given
-    if (this.sparklineChartId === undefined) {
-      this.sparklineChartId = 'sparklineChart';
-      if (this.config.chartId) {
-        this.sparklineChartId = this.config.chartId + this.sparklineChartId;
-      }
-    }
-
+    this.setupConfigDefaults();
     this.setupConfig();
-    this.updateAll();
-    super.generateChart(this.sparklineChartId);
+    this.generateChart(this.config, true);
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
-    // Do a deep compare on config
-    if (!isEqual(this.chartData, this.prevChartData)) {
-      this.updateAll();
-    }
-
-    if (!isEqual(this.config, this.prevConfig)) {
+    if (!isEqual(this.config, this.prevConfig) || !isEqual(this.chartData, this.prevChartData)) {
       this.setupConfig();
-      this.generateChart(this.sparklineChartId, true);
+      this.generateChart(this.config, true);
     }
   }
 
   /**
-   * Tooltip function for sparklines
-   * @returns {{contents: ((d:any)=>string), position: ((data:any, width:number,
-   * height:number, element:any)=>{top: number, left: number})}}
+   * Set up default config
    */
-  public sparklineTooltip() {
-    return {
-      contents: (d: any) => {
-        let tipRows;
-        let percentUsed = 0;
-
-        if (this.config.tooltipFn) {
-          tipRows = this.config.tooltipFn(d);
-        } else {
-          switch (this.config.tooltipType) {
-            case 'usagePerDay':
-              if (this.chartData.dataAvailable !== false && this.chartData.total > 0) {
-                percentUsed = Math.round(d[0].value / this.chartData.total * 100.0);
-              }
-              tipRows =
-                '<tr>' +
-                '  <th colspan="2">' + d[0].x.toLocaleDateString() + '</th>' +
-                '</tr>' +
-                '<tr>' +
-                '  <td class="name">' + percentUsed + '%:' + '</td>' +
-                '  <td class="value text-nowrap">' + d[0].value + ' '
-                  + (this.config.units ? this.config.units + ' ' : '') + d[0].name + '</td>' +
-                '</tr>';
-              break;
-            case 'valuePerDay':
-              tipRows =
-                '<tr>' +
-                '  <td class="value">' + d[0].x.toLocaleDateString() + '</td>' +
-                '  <td class="value text-nowrap">' + d[0].value + ' ' + d[0].name + '</td>' +
-                '</tr>';
-              break;
-            case 'percentage':
-              percentUsed = Math.round(d[0].value / this.chartData.total * 100.0);
-              tipRows =
-                '<tr>' +
-                '  <td class="name">' + percentUsed + '%' + '</td>' +
-                '</tr>';
-              break;
-            default:
-              tipRows = this.chartDefaults.getDefaultSparklineTooltip().contents(d);
-          }
-        }
-        return this.getTooltipTableHTML(tipRows);
-      },
-      position: (data: any, width: number, height: number, element: any) => {
-        let center;
-        let top;
-        let chartBox;
-        let graphOffsetX;
-        let x;
-
-        try {
-          center = parseInt(element.getAttribute('x'), 10);
-          top = parseInt(element.getAttribute('y'), 10);
-          chartBox = document.querySelector('#' + this.sparklineChartId).getBoundingClientRect();
-          graphOffsetX = document.querySelector('#' + this.sparklineChartId + ' g.c3-axis-y')
-            .getBoundingClientRect().right;
-          x = Math.max(0, center + graphOffsetX - chartBox.left - Math.floor(width / 2));
-
-          return {
-            top: top - height,
-            left: Math.min(x, chartBox.width - width)
-          };
-        } catch (e) {
-        }
-      }
-    };
-  }
-
-
-  /*
-   * Convert the config data to C3 Data
-   */
-  protected getSparklineData(chartData: any): any {
-    let sparklineData: any = {
-      type: 'area'
-    };
-
-    if (chartData && chartData.dataAvailable !== false && chartData.xData && chartData.yData) {
-      sparklineData.x = chartData.xData[0];
-      sparklineData.columns = [
-        chartData.xData,
-        chartData.yData
-      ];
+  protected setupConfig(): void {
+    if (this.config !== undefined) {
+      defaultsDeep(this.config, this.defaultConfig);
+    } else {
+      this.config = cloneDeep(this.defaultConfig);
     }
 
-    return sparklineData;
+    /*
+     * Setup Axis options. Default is to not show either axis. This can be overridden in two ways:
+     *   1) in the config, setting showAxis to true will show both axes
+     *   2) in the attributes showXAxis and showYAxis will override the config if set
+     *
+     * By default only line and the tick marks are shown, no labels. This is a sparkline and should be used
+     * only to show a brief idea of trending. This can be overridden by setting the config.axis options per C3
+     */
+    if (this.config.axis !== undefined) {
+      this.config.axis.x.show = this.config.showXAxis === true;
+      this.config.axis.y.show = this.config.showYAxis === true;
+    }
+    if (this.config.chartHeight !== undefined) {
+      this.config.size.height = this.config.chartHeight;
+    }
+    this.config.data = merge(this.config.data, this.getChartData());
+    this.prevConfig = cloneDeep(this.config);
+    this.prevChartData = cloneDeep(this.chartData);
   }
 
-  private setupConfig(): void {
+  /**
+   * Set up config defaults
+   */
+  protected setupConfigDefaults(): void {
     this.defaultConfig = this.chartDefaults.getDefaultSparklineConfig();
+
     this.defaultConfig.axis = {
       x: {
         show: this.config.showXAxis === true,
@@ -187,39 +118,102 @@ export class SparklineComponent extends ChartBase implements DoCheck, OnInit {
         }
       }
     };
-
-    // Setup the default configuration
-    this.defaultConfig.tooltip = this.sparklineTooltip();
+    this.defaultConfig.chartId = uniqueId(this.config.chartId);
+    this.defaultConfig.data = { type: 'area' };
+    this.defaultConfig.tooltip = this.tooltip();
     this.defaultConfig.units = '';
-
-    // Override defaults with callers specifications
-    defaults(this.config, this.defaultConfig);
-
-    if (this.config.chartHeight) {
-      this.defaultConfig.size.height = this.config.chartHeight;
-      this.config.size.height = this.config.chartHeight;
-    }
-
-    /*
-     * Setup Axis options. Default is to not show either axis. This can be overridden in two ways:
-     *   1) in the config, setting showAxis to true will show both axes
-     *   2) in the attributes showXAxis and showYAxis will override the config if set
-     *
-     * By default only line and the tick marks are shown, no labels. This is a sparkline and should be used
-     * only to show a brief idea of trending. This can be overridden by setting the config.axis options per C3
-     */
-    if (this.config.axis) {
-      this.config.axis.x.show = this.config.showXAxis === true;
-      this.config.axis.y.show = this.config.showYAxis === true;
-    }
   }
 
-  private updateAll(): void {
-    // Need to deep watch changes in chart data
-    this.prevChartData = cloneDeep(this.chartData);
-    // Convert the given data to C3 chart format
-    this.config.data = merge(this.config.data, this.getSparklineData(this.chartData));
+  // Chart
+
+  /**
+   * Convert chartData to C3 data property
+   */
+  protected getChartData(): any {
+    let data: any = {};
+
+    if (this.chartData && this.chartData.dataAvailable !== false && this.chartData.xData && this.chartData.yData) {
+      data.x = this.chartData.xData[0];
+      data.columns = [
+        this.chartData.xData,
+        this.chartData.yData
+      ];
+    }
+    return data;
   }
+
+  /**
+   * Tooltip function for sparklines
+   *
+   * @returns {{contents: ((d:any)=>string), position: ((data:any, width:number,
+   *            height:number, element:any)=>{top: number, left: number})}}
+   */
+  tooltip(): any {
+    return {
+      contents: (d: any) => {
+        let tipRows;
+        let percentUsed = 0;
+
+        switch (this.config.tooltipType) {
+          case 'usagePerDay':
+            if (this.chartData.dataAvailable !== false && this.chartData.total > 0) {
+              percentUsed = Math.round(d[0].value / this.chartData.total * 100.0);
+            }
+            tipRows =
+              '<tr>' +
+              '  <th colspan="2">' + d[0].x.toLocaleDateString() + '</th>' +
+              '</tr>' +
+              '<tr>' +
+              '  <td class="name">' + percentUsed + '%:' + '</td>' +
+              '  <td class="value text-nowrap">' + d[0].value + ' '
+              + (this.config.units ? this.config.units + ' ' : '') + d[0].name + '</td>' +
+              '</tr>';
+            break;
+          case 'valuePerDay':
+            tipRows =
+              '<tr>' +
+              '  <td class="value">' + d[0].x.toLocaleDateString() + '</td>' +
+              '  <td class="value text-nowrap">' + d[0].value + ' ' + d[0].name + '</td>' +
+              '</tr>';
+            break;
+          case 'percentage':
+            percentUsed = Math.round(d[0].value / this.chartData.total * 100.0);
+            tipRows =
+              '<tr>' +
+              '  <td class="name">' + percentUsed + '%' + '</td>' +
+              '</tr>';
+            break;
+          default:
+            tipRows = this.chartDefaults.getDefaultSparklineTooltip().contents(d);
+        }
+        return this.getTooltipTableHTML(tipRows);
+      },
+      position: (data: any, width: number, height: number, element: any) => {
+        let center;
+        let top;
+        let chartBox;
+        let graphOffsetX;
+        let x;
+
+        try {
+          center = parseInt(element.getAttribute('x'), 10);
+          top = parseInt(element.getAttribute('y'), 10);
+          chartBox = document.querySelector('#' + this.config.chartId).getBoundingClientRect();
+          graphOffsetX = document.querySelector('#' + this.config.chartId + ' g.c3-axis-y')
+            .getBoundingClientRect().right;
+          x = Math.max(0, center + graphOffsetX - chartBox.left - Math.floor(width / 2));
+
+          return {
+            top: top - height,
+            left: Math.min(x, chartBox.width - width)
+          };
+        } catch (e) {
+        }
+      }
+    };
+  }
+
+  // Private
 
   private getTooltipTableHTML(tipRows: any): string {
     return '<div class="module-triangle-bottom">' +


### PR DESCRIPTION
Refactored sparkline and donut charts to update config and chart data properly. Whenever chartData is merged with config.data, the component would detect an unnecessary change.

Also fixed:

- Fixed merging of chartData to c3 config.data
- Moved dynamic chart to its own example tab
- Consolidated multiple ID properties (id, bindto, and chartId) as chartId
- Added unique id if chartId is not provided
- Added missing exports to chart.module and index.js
- Added missing API comments for TypeDoc
- Added missing config and data types
- Added missing window ref
- Created SparklineData type
- Destroy subscriptions

https://rawgit.com/dlabrecq/patternfly-ng/chart-dist/dist-demo/#/donut