### PR TITLE
prevConfig should be cloned after setting config properties

### DIFF
--- a/src/app/action/action.component.ts
+++ b/src/app/action/action.component.ts
@@ -59,14 +59,14 @@ export class ActionComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -84,6 +84,7 @@ export class ActionComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Private

--- a/src/app/filter/filter-fields.component.ts
+++ b/src/app/filter/filter-fields.component.ts
@@ -64,14 +64,14 @@ export class FilterFieldsComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -89,7 +89,6 @@ export class FilterFieldsComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
-    this.prevConfig = cloneDeep(this.config);
 
     if (this.config && this.config.fields === undefined) {
       this.config.fields = [];
@@ -98,6 +97,7 @@ export class FilterFieldsComponent implements DoCheck, OnInit {
       this.config.tooltipPlacement = 'top';
     }
     this.initCurrentField();
+    this.prevConfig = cloneDeep(this.config);
   }
 
   /**

--- a/src/app/filter/filter-results.component.ts
+++ b/src/app/filter/filter-results.component.ts
@@ -52,14 +52,14 @@ export class FilterResultsComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -77,7 +77,6 @@ export class FilterResultsComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
-    this.prevConfig = cloneDeep(this.config);
 
     if (this.config && this.config.appliedFilters === undefined) {
       this.config.appliedFilters = [];
@@ -91,6 +90,7 @@ export class FilterResultsComponent implements DoCheck, OnInit {
     if (this.config && this.config.totalCount === undefined) {
       this.config.totalCount = 0;
     }
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Private

--- a/src/app/filter/filter.component.ts
+++ b/src/app/filter/filter.component.ts
@@ -74,14 +74,14 @@ export class FilterComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -99,11 +99,11 @@ export class FilterComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
-    this.prevConfig = cloneDeep(this.config);
 
     if (this.config && this.config.appliedFilters === undefined) {
       this.config.appliedFilters = [];
     }
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Actions

--- a/src/app/pagination/pagination.component.ts
+++ b/src/app/pagination/pagination.component.ts
@@ -54,7 +54,7 @@ export class PaginationComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
@@ -62,7 +62,7 @@ export class PaginationComponent implements DoCheck, OnInit {
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -80,8 +80,8 @@ export class PaginationComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
-    this.prevConfig = cloneDeep(this.config);
     this.pageNumber = this.config.pageNumber;
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Getters and setters

--- a/src/app/sort/sort.component.ts
+++ b/src/app/sort/sort.component.ts
@@ -48,14 +48,14 @@ export class SortComponent implements DoCheck, OnInit {
   }
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -82,6 +82,7 @@ export class SortComponent implements DoCheck, OnInit {
         this.config.isAscending = true;
       }
     }
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Actions

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -90,14 +90,14 @@ export class ToolbarComponent implements DoCheck, OnInit {
   // Initialization
 
   /**
-   *  Setup component configuration upon initialization
+   * Setup component configuration upon initialization
    */
   ngOnInit(): void {
     this.setupConfig();
   }
 
   /**
-   *  Check if the component config has changed
+   * Check if the component config has changed
    */
   ngDoCheck(): void {
     // Do a deep compare on config
@@ -132,6 +132,7 @@ export class ToolbarComponent implements DoCheck, OnInit {
     if (this.config && this.config.view === undefined) {
       this.config.view = this.config.views[0];
     }
+    this.prevConfig = cloneDeep(this.config);
   }
 
   // Actions


### PR DESCRIPTION
We're testing prevConfig, but not actually setting it. This must also be cloned after setting any config properties. That way we can properly detect if the config changed.

https://rawgit.com/dlabrecq/patternfly-ng/prevConfig-dist/dist-demo/