### PR TITLE
Reverted typedoc back to ^0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "ts-helpers": "1.1.2",
     "ts-node": "2.1.0",
     "tslint": "5.8.0",
-    "typedoc": "0.9.0",
+    "typedoc": "^0.5.7",
     "typedoc-webpack-plugin": "1.1.4",
     "typescript": "^2.3.4",
     "url-loader": "0.5.8",


### PR DESCRIPTION
Seeing recurring “JavaScript heap out of memory” error messages when running the demo.

The errors I encountered (parseJSDocCommentWorker/parseJSDocComment) appear to be related to the recent typedoc update? At least, the version of typescript pulled in. Reverting back to typedoc ^0.5.7 seems to be working for me. 

typedoc pulls in typescript@2.2.2, while the patternfly-ng pulls typescript@2.4.1. We need 2.4.1 to be compatible with Angular 5, but it's probably ok for generating typedoc.