### PR TITLE
List pin sort should be based on boolean values

### DIFF
--- a/src/app/list/basic-list/examples/list-pin-example.component.ts
+++ b/src/app/list/basic-list/examples/list-pin-example.component.ts
@@ -38,7 +38,8 @@ export class ListPinExampleComponent implements OnInit {
       clusterCount: 6,
       hostCount: 8,
       imageCount: 8,
-      nodeCount: 10
+      nodeCount: 10,
+      showPin: false
     }, {
       name: 'John Smith',
       address: '415 East Main Street',
@@ -60,7 +61,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Linda McGovern',
       address: '22 Oak Street',
@@ -81,7 +83,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Holly Nichols',
       address: '21 Jump Street',
@@ -102,7 +105,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Pat Thomas',
       address: '50 Second Street',
@@ -112,7 +116,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }];
     this.items = cloneDeep(this.allItems);
 

--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -34,7 +34,7 @@
   <!-- items -->
   <div class="list-pf-item {{item?.itemStyleClass}}"
        [ngClass]="{'active': item.selected || item.isItemExpanded}"
-       *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin') : items); let i = index">
+       *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
     <div class="list-pf-container">
       <!-- pin -->
       <div class="pfng-list-pin-container" *ngIf="config.usePinItems">


### PR DESCRIPTION
In order to ensure pins are sorted properly, all list items must have a showPin boolean value. 

Testing showPin=true and showPin=undefined does not result in the same sort order -- showPin=undefined is sorted before showPin=true/false.