### PR TITLE
Clean up test for sort array pipe

### DIFF
--- a/src/app/list/basic-list/examples/list-pin-example.component.ts
+++ b/src/app/list/basic-list/examples/list-pin-example.component.ts
@@ -38,7 +38,8 @@ export class ListPinExampleComponent implements OnInit {
       clusterCount: 6,
       hostCount: 8,
       imageCount: 8,
-      nodeCount: 10
+      nodeCount: 10,
+      showPin: false
     }, {
       name: 'John Smith',
       address: '415 East Main Street',
@@ -60,7 +61,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Linda McGovern',
       address: '22 Oak Street',
@@ -81,7 +83,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Holly Nichols',
       address: '21 Jump Street',
@@ -102,7 +105,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }, {
       name: 'Pat Thomas',
       address: '50 Second Street',
@@ -112,7 +116,8 @@ export class ListPinExampleComponent implements OnInit {
       hostCount: 8,
       clusterCount: 6,
       nodeCount: 10,
-      imageCount: 8
+      imageCount: 8,
+      showPin: false
     }];
     this.items = cloneDeep(this.allItems);
 

--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -34,7 +34,7 @@
   <!-- items -->
   <div class="list-pf-item {{item?.itemStyleClass}}"
        [ngClass]="{'active': item.selected || item.isItemExpanded}"
-       *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin') : items); let i = index">
+       *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
     <div class="list-pf-container">
       <!-- pin -->
       <div class="pfng-list-pin-container" *ngIf="config.usePinItems">

--- a/src/app/pipe/sort-array/sort-array.pipe.spec.ts
+++ b/src/app/pipe/sort-array/sort-array.pipe.spec.ts
@@ -9,29 +9,32 @@ describe('Sort array pipe', () => {
       name: 'Fred Flintstone',
       address: '20 Dinosaur Way',
       city: 'Bedrock',
-      state: 'Washingstone'
+      state: 'Washingstone',
+      showPin: false
     }, {
       name: 'John Smith',
       address: '415 East Main Street',
       city: 'Norfolk',
       state: 'Virginia',
-      pin: true
+      showPin: true
     }, {
       name: 'Frank Livingston',
       address: '234 Elm Street',
       city: 'Pittsburgh',
-      state: 'Pennsylvania'
+      state: 'Pennsylvania',
+      showPin: false
     }, {
       name: 'Linda McGovern',
       address: '22 Oak Street',
       city: 'Denver',
       state: 'Colorado',
-      pin: true
+      showPin: true
     }, {
       name: 'Jim Brown',
       address: '72 Bourbon Way',
       city: 'Nashville',
-      state: 'Tennessee'
+      state: 'Tennessee',
+      showPin: false
     }, {
       name: 'Holly Nichols',
       address: '21 Jump Street',
@@ -42,12 +45,14 @@ describe('Sort array pipe', () => {
       name: 'Marie Edwards',
       address: '17 Cross Street',
       city: 'Boston',
-      state: 'Massachusetts'
+      state: 'Massachusetts',
+      showPin: false
     }, {
       name: 'Pat Thomas',
       address: '50 Second Street',
       city: 'New York',
-      state: 'New York'
+      state: 'New York',
+      showPin: false
     }];
   });
 
@@ -63,7 +68,7 @@ describe('Sort array pipe', () => {
 
   it('should sort array by "name", then sort array by "pin"', () => {
     let sortedItems = pipe.transform(items, 'name');
-    sortedItems = pipe.transform(sortedItems, 'pin');
+    sortedItems = pipe.transform(sortedItems, 'showPin', true);
     expect(sortedItems[0].name).toBe('Holly Nichols');
   });
 });


### PR DESCRIPTION
In order to ensure pins are sorted properly, all list items must have a showPin boolean value.

Testing showPin=true and showPin=undefined does not result in the same sort order -- showPin=undefined is sorted before showPin=true/false.