### PR TITLE
List: adjust pin placeholder to better align text

### DIFF
--- a/src/app/list/basic-list/list.component.less
+++ b/src/app/list/basic-list/list.component.less
@@ -107,7 +107,7 @@
 // Pin placeholder for heading and non-pinned items
 .pfng-list-pin-placeholder {
   margin-left: -20px;
-  width: 38px;
+  width: 39px;
   &.multi-ctrls {
     width: 28px;
   }


### PR DESCRIPTION
Adjusting the list pin placeholder to better align text.

FYI, this tweak is needed to better align list items in OSIO.