### PR TITLE
feat(notifications): add observable for watching notifications array

### DIFF
--- a/src/app/list/basic-list/examples/list-example.component.html
+++ b/src/app/list/basic-list/examples/list-example.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-xs-12">
       <h4>List Component Example</h4>
-      <hr/>
+      <hr>
     </div>
   </div>
   <tabset>

--- a/src/app/notification/examples/notification-example.module.ts
+++ b/src/app/notification/examples/notification-example.module.ts
@@ -9,6 +9,8 @@ import { DemoComponentsModule } from '../../../demo/components/demo-components.m
 import { NotificationModule } from '../notification.module';
 import { NotificationService } from '../notification.service';
 import { NotificationServiceExampleComponent } from './notification-service-example.component';
+import { NotificationServiceBasicExampleComponent } from './notification-service-basic-example.component';
+import { NotificationServiceObserverExampleComponent } from './notification-service-observer-example.component';
 import { ToastNotificationExampleComponent } from './toast-notification-example.component';
 import { ToastNotificationListExampleComponent } from './toast-notification-list-example.component';
 import { InlineNotificationExampleComponent } from './inline-notification-example.component';
@@ -17,6 +19,8 @@ import { InlineNotificationExampleComponent } from './inline-notification-exampl
   declarations: [
     InlineNotificationExampleComponent,
     NotificationServiceExampleComponent,
+    NotificationServiceBasicExampleComponent,
+    NotificationServiceObserverExampleComponent,
     ToastNotificationExampleComponent,
     ToastNotificationListExampleComponent
   ],

--- a/src/app/notification/examples/notification-service-basic-example.component.html
+++ b/src/app/notification/examples/notification-service-basic-example.component.html
@@ -1,0 +1,29 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <h2>This example sets the notification service delay to 5 seconds.</h2>
+        <pfng-toast-notification-list [notifications]="notifications"></pfng-toast-notification-list>
+      </div>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-xs-12">
+      <h4>Code</h4>
+      <hr>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="api">
+        <iframe class="demoframe" src="docs/classes/notificationservice.html"></iframe>
+      </tab>
+      <tab heading="html">
+        <include-content src="src/app/notification/examples/notification-service-basic-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="src/app/notification/examples/notification-service-basic-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/notification/examples/notification-service-basic-example.component.ts
+++ b/src/app/notification/examples/notification-service-basic-example.component.ts
@@ -1,0 +1,36 @@
+import {
+  Component,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Notification } from '../notification';
+import { NotificationService } from '../notification.service';
+import { NotificationType } from '../notification-type';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'notification-service-basic-example',
+  templateUrl: './notification-service-basic-example.component.html'
+})
+export class NotificationServiceBasicExampleComponent implements OnInit {
+  notifications: Notification[];
+
+  constructor(private notificationService: NotificationService) {
+    this.notifications = this.notificationService.getNotifications();
+
+    notificationService.setDelay(5000); // default is 8000
+  }
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.notificationService.message(
+        NotificationType.WARNING,
+        'Default Header.',
+        'Default Message.',
+        false,
+        null,
+        null);
+    }, 500);
+  }
+}

--- a/src/app/notification/examples/notification-service-example.component.html
+++ b/src/app/notification/examples/notification-service-example.component.html
@@ -1,29 +1,16 @@
 <div class="padding-15">
-  <div class="row">
-    <div class="col-sm-12">
-      <div class="form-group">
-        <h2>This example sets the notification service delay to 5 seconds.</h2>
-        <pfng-toast-notification-list [notifications]="notifications"></pfng-toast-notification-list>
+    <div class="row">
+      <div class="col-xs-12">
+        <h4>Notification Service Example</h4>
+        <hr>
       </div>
     </div>
-  </div>
-  <div class="row padding-bottom-15 padding-top-15">
-    <div class="col-xs-12">
-      <h4>Code</h4>
-      <hr/>
-    </div>
-  </div>
-  <div>
     <tabset>
-      <tab heading="api">
-        <iframe class="demoframe" src="docs/classes/notificationservice.html"></iframe>
+      <tab heading="Basic" (select)="tabSelected($event)">
+        <notification-service-basic-example *ngIf="activeTab === 'Basic' || activeTab === ''"></notification-service-basic-example>
       </tab>
-      <tab heading="html">
-        <include-content src="src/app/notification/examples/notification-service-example.component.html"></include-content>
-      </tab>
-      <tab heading="typescript">
-        <include-content src="src/app/notification/examples/notification-service-example.component.ts"></include-content>
+      <tab heading="Observer" (select)="tabSelected($event)">
+        <notification-service-observer-example *ngIf="activeTab === 'Observer'"></notification-service-observer-example>
       </tab>
     </tabset>
   </div>
-</div>

--- a/src/app/notification/examples/notification-service-example.component.ts
+++ b/src/app/notification/examples/notification-service-example.component.ts
@@ -4,9 +4,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { Notification } from '../notification';
-import { NotificationService } from '../notification.service';
-import { NotificationType } from '../notification-type';
+import { TabDirective } from 'ngx-bootstrap/tabs';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -14,21 +12,19 @@ import { NotificationType } from '../notification-type';
   templateUrl: './notification-service-example.component.html'
 })
 export class NotificationServiceExampleComponent implements OnInit {
-  notifications: Notification[];
+  activeTab: string = '';
 
-  constructor(private notificationService: NotificationService) {
-    this.notifications = this.notificationService.getNotifications();
-
-    notificationService.setDelay(5000); // default is 8000
+  constructor() {
   }
 
   ngOnInit(): void {
-    this.notificationService.message(
-      NotificationType.WARNING,
-      'Default Header.',
-      'Default Message.',
-      false,
-      null,
-      null);
+  }
+
+  ngDoCheck(): void {
+  }
+
+  // Actions
+  tabSelected($event: TabDirective): void {
+    this.activeTab = $event.heading;
   }
 }

--- a/src/app/notification/examples/notification-service-observer-example.component.html
+++ b/src/app/notification/examples/notification-service-observer-example.component.html
@@ -3,8 +3,9 @@
       <div class="col-sm-12">
         <div class="form-group">
           <h2>This example illustrates subscribing to the notifications observer.</h2>
-          <p>Using a standard 8 second delay, this example launches a new message every second for 6 seconds, logging the notification to the console each time.</p>
+          <p>Click the button below to launch a notification, and view the logs in the console to see the subscription in action.</p>
           <p>This method of getting notifications becomes necessary when using the OnPush ChangeDetectionStrategy in Angular.</p>
+          <button class="btn btn-default" (click)="launchNotification()">Launch Notification</button>
           <pfng-toast-notification-list [notifications]="notifications|async"></pfng-toast-notification-list>
         </div>
       </div>

--- a/src/app/notification/examples/notification-service-observer-example.component.html
+++ b/src/app/notification/examples/notification-service-observer-example.component.html
@@ -1,0 +1,31 @@
+<div class="padding-15">
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="form-group">
+          <h2>This example illustrates subscribing to the notifications observer.</h2>
+          <p>Using a standard 8 second delay, this example launches a new message every second for 6 seconds, logging the notification to the console each time.</p>
+          <p>This method of getting notifications becomes necessary when using the OnPush ChangeDetectionStrategy in Angular.</p>
+          <pfng-toast-notification-list [notifications]="notifications|async"></pfng-toast-notification-list>
+        </div>
+      </div>
+    </div>
+    <div class="row padding-bottom-15 padding-top-15">
+      <div class="col-xs-12">
+        <h4>Code</h4>
+        <hr>
+      </div>
+    </div>
+    <div>
+      <tabset>
+        <tab heading="api">
+          <iframe class="demoframe" src="docs/classes/notificationservice.html"></iframe>
+        </tab>
+        <tab heading="html">
+          <include-content src="src/app/notification/examples/notification-service-observer-example.component.html"></include-content>
+        </tab>
+        <tab heading="typescript">
+          <include-content src="src/app/notification/examples/notification-service-observer-example.component.ts"></include-content>
+        </tab>
+      </tabset>
+    </div>
+  </div>

--- a/src/app/notification/examples/notification-service-observer-example.component.ts
+++ b/src/app/notification/examples/notification-service-observer-example.component.ts
@@ -20,32 +20,28 @@ import { Observable } from 'rxjs';
     notifications: Observable<Notification[]>;
 
     constructor(private notificationService: NotificationService) {
-      notificationService.setDelay(8000);
     }
 
     ngOnInit(): void {
       this.notifications = this.notificationService.getNotificationsObserver;
       // Display notifications to illustrate how
       // one can react to a notifications observer
-      const exampleTimer = setInterval(_ => {
-        this.notificationService.message(
-          NotificationType.SUCCESS,
-          'Example header',
-          'Open js console to see notifications observer in action',
-          false,
-          null,
-          null
-        );
-      }, 1000);
-
-      setTimeout(_ => {
-        clearInterval(exampleTimer);
-      }, 6000);
 
       // Track Notifications
       this.notificationService.getNotificationsObserver
         .subscribe((notification) => {
           console.log(notification);
         });
+    }
+
+    launchNotification(): void {
+      this.notificationService.message(
+        NotificationType.SUCCESS,
+        'Example header',
+        'Open js console to see notifications observer in action',
+        false,
+        null,
+        null
+      );
     }
   }

--- a/src/app/notification/examples/notification-service-observer-example.component.ts
+++ b/src/app/notification/examples/notification-service-observer-example.component.ts
@@ -1,0 +1,51 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    OnInit,
+    ViewEncapsulation
+  } from '@angular/core';
+import { Observable } from 'rxjs';
+
+  import { Notification } from '../notification';
+  import { NotificationService } from '../notification.service';
+  import { NotificationType } from '../notification-type';
+
+  @Component({
+    encapsulation: ViewEncapsulation.None,
+    selector: 'notification-service-observer-example',
+    templateUrl: './notification-service-observer-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+  })
+  export class NotificationServiceObserverExampleComponent implements OnInit {
+    notifications: Observable<Notification[]>;
+
+    constructor(private notificationService: NotificationService) {
+      notificationService.setDelay(8000);
+    }
+
+    ngOnInit(): void {
+      this.notifications = this.notificationService.getNotificationsObserver;
+      // Display notifications to illustrate how
+      // one can react to a notifications observer
+      const exampleTimer = setInterval(_ => {
+        this.notificationService.message(
+          NotificationType.SUCCESS,
+          'Example header',
+          'Open js console to see notifications observer in action',
+          false,
+          null,
+          null
+        );
+      }, 1000);
+
+      setTimeout(_ => {
+        clearInterval(exampleTimer);
+      }, 6000);
+
+      // Track Notifications
+      this.notificationService.getNotificationsObserver
+        .subscribe((notification) => {
+          console.log(notification);
+        });
+    }
+  }

--- a/src/demo/app.component.html
+++ b/src/demo/app.component.html
@@ -13,7 +13,7 @@
           <a routerLink="/" routerLinkActive="active">Home</a>
         </li>
       </ul>
-      <hr/>
+      <hr>
       <h3>Components</h3>
       <ul>
         <li>
@@ -98,7 +98,7 @@
           <a routerLink="/wizard" routerLinkActive="active">Wizard</a>
         </li>
       </ul>
-      <hr/>
+      <hr>
       <h3>Directives</h3>
       <ul>
         <li>


### PR DESCRIPTION
This PR introduces a new property (getNotificationsObserver) to the notification service which wraps the notifications array in an observable. This became necessary when we realized the existing getNotifications() method doesn't work so well while using the OnPush ChangeDetectionStrategy in Angular.

Solves [[issue-222]](https://github.com/patternfly/patternfly-ng/issues/222)

One specific thing I'd like feedback on is how I'm using clearInterval() for the example timer. It works fine in general, but when switching between the tabs quickly you end up building a queue of notifications because the clearInterval doesn't seem to get called if that view is not active. A better approach may be to clearInterval on switching between the tabs, but how to access the timer from within the tabSelected event in notification-service-example.component.ts?

https://rawgit.com/seanforyou23/patternfly-ng/notifications-observable-dist/dist-demo/#/notificationservice

add a new getNotificationsObserver property which allows for listening in on notifications activity
update stream on add/remove notification from data source
add a simple wrapper function for updating the stream to enforce DRY
includes example files for demo app
