### PR TITLE
Column reordering

### DIFF
--- a/src/app/table/datatable/datatable.component.less
+++ b/src/app/table/datatable/datatable.component.less
@@ -185,6 +185,9 @@
       .datatable-header-cell-label {
         line-height: 24px;
       }
+      .datatable-header-cell-wrapper {
+        cursor: pointer;
+      }
     }
     .datatable-body {
       &-row {

--- a/src/app/table/datatable/datatable.component.ts
+++ b/src/app/table/datatable/datatable.component.ts
@@ -156,6 +156,7 @@ export class DataTableComponent extends TableBase implements DoCheck, OnInit {
         canAutoResize: false,
         cellClass: 'pfng-datatable-select ' + cellClass,
         cellTemplate: this.selectCellTemplate,
+        // frozenLeft: true,
         headerClass: 'pfng-datatable-select ' + cellClass,
         headerTemplate: this.selectHeadTemplate,
         name: '_select',

--- a/src/app/table/datatable/examples/datatable-example.component.html
+++ b/src/app/table/datatable/examples/datatable-example.component.html
@@ -26,29 +26,17 @@
             (onViewSelect)="viewSelected($event)">
         </pfng-datatable>
         <!-- Column templates -->
-        <ng-template #nameHeadTemplate let-column="column">
-          <span>{{column.name}}</span>
-        </ng-template>
-        <ng-template #nameCellTemplate let-row="row">
+        <ng-template #nameTemplate let-row="row">
           <span>{{row.name}}</span>
         </ng-template>
-        <ng-template #addressHeadTemplate let-column="column">
-          <span>{{column.name}}</span>
-        </ng-template>
-        <ng-template #addressCellTemplate let-row="row">
+        <ng-template #addressTemplate let-row="row">
           <span>{{row.address}}</span>
         </ng-template>
-        <ng-template #brithMonthHeadTemplate let-column="column">
-          <span>{{column.name}}</span>
-        </ng-template>
-        <ng-template #brithMonthCellTemplate let-row="row">
+        <ng-template #birthMonthTemplate let-row="row">
           <span>{{row.birthMonth}}</span>
         </ng-template>
-        <ng-template #weekDayHeadTemplate let-column="column">
-          <span>{{column.name}}</span>
-        </ng-template>
-        <ng-template #weekDayCellTemplate let-row="row">
-          <span>{{row.birthMonth}}</span>
+        <ng-template #weekDayTemplate let-row="row">
+          <span>{{row.weekDay}}</span>
         </ng-template>
         <!-- Row detail template -->
         <ng-template #expandRowTemplate let-row="row">

--- a/src/app/table/datatable/examples/datatable-example.component.ts
+++ b/src/app/table/datatable/examples/datatable-example.component.ts
@@ -31,15 +31,11 @@ import { cloneDeep } from 'lodash';
   templateUrl: './datatable-example.component.html'
 })
 export class DataTableExampleComponent implements OnInit {
-  @ViewChild('addressCellTemplate') addressCellTemplate: TemplateRef<any>;
-  @ViewChild('addressHeadTemplate') addressHeadTemplate: TemplateRef<any>;
-  @ViewChild('birthMonthCellTemplate') birthMonthCellTemplate: TemplateRef<any>;
-  @ViewChild('birthMonthHeadTemplate') birthMonthHeadTemplate: TemplateRef<any>;
+  @ViewChild('addressTemplate') addressTemplate: TemplateRef<any>;
+  @ViewChild('birthMonthTemplate') birthMonthTemplate: TemplateRef<any>;
   @ViewChild('expandRowTemplate') expandRowTemplate: TemplateRef<any>;
-  @ViewChild('nameCellTemplate') nameCellTemplate: TemplateRef<any>;
-  @ViewChild('nameHeadTemplate') nameHeadTemplate: TemplateRef<any>;
-  @ViewChild('weekDayCellTemplate') weekDayCellTemplate: TemplateRef<any>;
-  @ViewChild('weekDayHeadTemplate') weekDayHeadTemplate: TemplateRef<any>;
+  @ViewChild('nameTemplate') nameTemplate: TemplateRef<any>;
+  @ViewChild('weekDayTemplate') weekDayTemplate: TemplateRef<any>;
 
   actionConfig: ActionConfig;
   actionsText: string = '';
@@ -90,29 +86,29 @@ export class DataTableExampleComponent implements OnInit {
 
   ngOnInit(): void {
     this.columns = [{
-      cellTemplate: this.nameCellTemplate,
+      cellTemplate: this.nameTemplate,
       draggable: true,
-      headerTemplate: this.nameHeadTemplate,
       prop: 'name',
-      name: 'Name'
+      name: 'Name',
+      resizeable: true
     }, {
-      cellTemplate: this.addressCellTemplate,
+      cellTemplate: this.addressTemplate,
       draggable: true,
-      headerTemplate: this.addressHeadTemplate,
       prop: 'address',
-      name: 'Address'
+      name: 'Address',
+      resizeable: true
     }, {
-      cellTemplate: this.birthMonthCellTemplate,
+      cellTemplate: this.birthMonthTemplate,
       draggable: true,
-      headerTemplate: this.birthMonthHeadTemplate,
       prop: 'birthMonth',
-      name: 'Birth Month'
+      name: 'Birth Month',
+      resizeable: true
     }, {
-      cellTemplate: this.weekDayCellTemplate,
+      cellTemplate: this.weekDayTemplate,
       draggable: true,
-      headerTemplate: this.weekDayHeadTemplate,
       prop: 'weekDay',
-      name: 'Week Day'
+      name: 'Week Day',
+      resizeable: true
     }];
 
     this.allRows = [{
@@ -331,11 +327,11 @@ export class DataTableExampleComponent implements OnInit {
     } as ToolbarConfig;
 
     this.dataTableConfig = {
-      dragEnabled: false,
+      dragEnabled: true,
       paginationConfig: this.paginationConfig,
-      showCheckbox: false,
+      showCheckbox: true,
       toolbarConfig: this.toolbarConfig,
-      useExpandRows: false
+      useExpandRows: true
     } as DataTableConfig;
   }
 


### PR DESCRIPTION
Removed header template for column reordering to work properly. Using a custom template omits the selectors required to reorder columns.