### PR TITLE
Add missing DonutComponent to index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ export { ChartConfig } from './src/app/chart/chart-config';
 export { ChartDefaults } from './src/app/chart/chart.defaults';
 export { ChartBase } from './src/app/chart/chart.base';
 export { ChartModule } from './src/app/chart/chart.module';
+export { DonutComponent } from './src/app/chart/donut/donut.component';
 export { DonutConfig } from './src/app/chart/donut/donut-config';
 export { SparklineComponent } from './src/app/chart/sparkline/sparkline.component';
 export { SparklineConfig } from './src/app/chart/sparkline/sparkline-config';


### PR DESCRIPTION
Currently, the DonutComponent class is not available in the patternfly-ng package.

"I had to add this line to the main index.ts `export { DonutComponent } from './src/app/chart/donut/donut.component';` to pick up the component for me locally"