### PR TITLE
Add resetFilterFields method to toolbar

### DIFF
--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -4,11 +4,12 @@
           [ngClass]="{'no-filter-results': config.filterConfig?.resultsCount === 0 && config.filterConfig?.appliedFilters?.length !== 0}"
           (submit)="$event.preventDefault()">
       <div class="form-group toolbar-apf-filter">
-        <pfng-filter-fields [config]="config.filterConfig" *ngIf="config.filterConfig?.fields"
+        <pfng-filter-fields [config]="config.filterConfig" #filterFields
                             (onAdd)="filterAdded($event)"
                             (onFieldSelect)="handleFilterFieldSelect($event)"
                             (onSave)="handleFilterSave($event)"
-                            (onTypeAhead)="handleFilterTypeAhead($event)"></pfng-filter-fields>
+                            (onTypeAhead)="handleFilterTypeAhead($event)"
+                            *ngIf="config.filterConfig?.fields"></pfng-filter-fields>
       </div>
       <div class="form-group" *ngIf="config.sortConfig?.fields && config.sortConfig?.visible !== false">
         <pfng-sort [config]="config.sortConfig" (onChange)="sortChange($event)"></pfng-sort>

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
   Output,
   TemplateRef,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 
@@ -13,6 +14,7 @@ import { cloneDeep, defaults, find, isEqual, remove } from 'lodash';
 
 import { Action } from '../action/action';
 import { Filter } from '../filter/filter';
+import { FilterFieldsComponent } from '../filter/filter-fields.component';
 import { FilterEvent } from '../filter/filter-event';
 import { SortEvent } from '../sort/sort-event';
 import { ToolbarConfig } from './toolbar-config';
@@ -77,6 +79,8 @@ export class ToolbarComponent implements DoCheck, OnInit {
    * The event emitted when a view has been selected
    */
   @Output('onViewSelect') onViewSelect = new EventEmitter();
+
+  @ViewChild('filterFields') private filterFields: FilterFieldsComponent;
 
   private defaultConfig: ToolbarConfig = {} as ToolbarConfig;
   private prevConfig: ToolbarConfig;
@@ -147,6 +151,15 @@ export class ToolbarComponent implements DoCheck, OnInit {
     this.onFilterChange.emit({
       appliedFilters: $event
     } as FilterEvent);
+  }
+
+  /**
+   * Reset current field and value
+   */
+  resetFilterField() {
+    if (this.filterFields !== undefined) {
+      this.filterFields.reset();
+    }
   }
 
   // Private


### PR DESCRIPTION
Add resetFilterFields method to toolbar.

This is a preferred solution for https://github.com/patternfly/patternfly-ng/pull/256 as we are currently using this approach with the save filter feature.