### PR TITLE
Add empty state example back in

### DIFF
--- a/src/demo/navbar/navbar-items.ts
+++ b/src/demo/navbar/navbar-items.ts
@@ -28,6 +28,10 @@ export class NavbarItems {
       title: 'Sparkline Chart'
     }]
   }, {
+    id: 'emptystate',
+    path: 'emptystate',
+    title: 'Empty State'
+  }, {
     id: 'filters',
     path: 'filters',
     title: 'Filter'


### PR DESCRIPTION
For some reason, the empty state example was omitted when the showcase was recently updated/prettified.

https://rawgit.com/dlabrecq/patternfly-ng/empty-state-dist/dist-demo/#/emptystate