### PR TITLE
Use lodash’s clone() function Vs deepClone() or none at all

### DIFF
--- a/src/app/action/action.component.ts
+++ b/src/app/action/action.component.ts
@@ -10,7 +10,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { cloneDeep, defaults, has, isEqual } from 'lodash';
+import { clone, cloneDeep, defaults, has, isEqual } from 'lodash';
 
 import { Action } from './action';
 import { ActionConfig } from './action-config';
@@ -84,18 +84,8 @@ export class ActionComponent implements DoCheck, OnInit {
     } else {
       this.config = cloneDeep(this.defaultConfig);
     }
-    // lodash has issues cloning primaryActions.template with the list component
-    let found = false;
-    if (this.config.primaryActions !== undefined) {
-      this.config.primaryActions.forEach((action) => {
-        if (has(action, 'template')) {
-          found = true;
-        }
-      });
-    }
-    if (!found) {
-      this.prevConfig = cloneDeep(this.config);
-    }
+    // lodash has issues deep cloning templates -- best seen with list component
+    this.prevConfig = clone(this.config);
   }
 
   // Private


### PR DESCRIPTION
Lodash has issues deep cloning templates in the config. However, instead of not cloning at all, lodash’s clone() function is sufficient for the action component.