### PR TITLE
Pagination: wrong start/end page indexes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -77,7 +77,7 @@ export { ToastNotificationListComponent } from './src/app/notification/toast-not
 // Pagination
 export { PaginationComponent } from './src/app/pagination/pagination.component';
 export { PaginationConfig } from './src/app/pagination/pagination-config';
-import { PaginationEvent } from './src/app/pagination/pagination-event';
+export { PaginationEvent } from './src/app/pagination/pagination-event';
 export { PaginationModule } from './src/app/pagination/pagination.module';
 
 // Pipes

--- a/src/app/pagination/pagination.component.ts
+++ b/src/app/pagination/pagination.component.ts
@@ -88,7 +88,7 @@ export class PaginationComponent implements DoCheck, OnInit {
   // Accessors
 
   get pageNumber(): number {
-    return this._pageNumber;
+    return (this.config.totalItems !== undefined && this.config.totalItems > 0) ? this._pageNumber : 0;
   }
 
   set pageNumber(pageNumber: number) {
@@ -99,7 +99,7 @@ export class PaginationComponent implements DoCheck, OnInit {
    * Return last page number
    */
   get lastPageNumber(): number {
-    return this._lastPageNumber;
+    return (this.config.totalItems !== undefined && this.config.totalItems > 0) ? this._lastPageNumber : 0;
   }
 
   /**
@@ -158,7 +158,8 @@ export class PaginationComponent implements DoCheck, OnInit {
    * Start Index of Current Page
    */
   getStartIndex(): number {
-    return (this.config.totalItems !== undefined) ? this.config.pageSize * (this.config.pageNumber - 1) + 1 : 0;
+    return (this.config.totalItems !== undefined && this.config.totalItems > 0)
+      ? this.config.pageSize * (this.config.pageNumber - 1) + 1 : 0;
   }
 
   /**
@@ -168,7 +169,8 @@ export class PaginationComponent implements DoCheck, OnInit {
     let numFullPages = Math.floor(this.config.totalItems / this.config.pageSize);
     let numItemsOnLastPage = this.config.totalItems - (numFullPages * this.config.pageSize) || this.config.pageSize;
     let numItemsOnPage = this.isLastPage() ? numItemsOnLastPage : this.config.pageSize;
-    return (this.config.totalItems !== undefined) ? this.getStartIndex() + numItemsOnPage - 1 : 0;
+    return (this.config.totalItems !== undefined && this.config.totalItems > 0)
+      ? (this.getStartIndex() + numItemsOnPage - 1) : 0;
   }
 
   /**


### PR DESCRIPTION
The pagination component shows the wrong start/end page indexes with an empty data set. For example, the current page should be 0, not 1. In addition, And instead of showing 1-1 of 1 items, I expect to see 0-0 of 0. 

This fix will be best seen with the new datatable -- no change for the existing example below.

https://rawgit.com/dlabrecq/patternfly-ng/pagination-dist/dist-demo/#/pagination
