### PR TITLE
Added disabled state for filter, sort, and toolbar

### DIFF
--- a/src/app/filter/examples/filter-basic-example.component.html
+++ b/src/app/filter/examples/filter-basic-example.component.html
@@ -35,6 +35,24 @@
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="disabled" name="disabled" type="checkbox"
+                   [(ngModel)]="filterConfig.disabled">Disabled
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-sm-12">
       <h4 class="actions-label">Filters</h4>
       <hr/>
     </div>

--- a/src/app/filter/examples/filter-save-example.component.html
+++ b/src/app/filter/examples/filter-save-example.component.html
@@ -52,6 +52,24 @@
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="disabled" name="disabled" type="checkbox"
+                   [(ngModel)]="filterConfig.disabled">Disabled
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-sm-12">
       <h4 class="actions-label">Filters</h4>
       <hr/>
     </div>

--- a/src/app/filter/filter-config.ts
+++ b/src/app/filter/filter-config.ts
@@ -11,6 +11,11 @@ export class FilterConfig {
   appliedFilters?: Filter[];
 
   /**
+   * A flag indicating the component is disabled
+   */
+  disabled?: boolean;
+
+  /**
    * A list of filterable fields
    */
   fields: FilterField[];

--- a/src/app/filter/filter-fields.component.html
+++ b/src/app/filter/filter-fields.component.html
@@ -2,7 +2,8 @@
   <div class="input-group form-group">
     <div class="input-group-btn" dropdown>
       <button type="button" class="btn btn-default filter-fields dropdown-toggle" dropdownToggle
-              tooltip="Filter by" placement="{{config?.tooltipPlacement}}">
+              tooltip="Filter by" placement="{{config?.tooltipPlacement}}"
+              [disabled]="config.disabled === true">
         {{currentField?.title}}
         <span class="caret"></span>
       </button>
@@ -21,11 +22,13 @@
     <div *ngIf="!currentField?.type || currentField?.type === 'text' || currentField.type === 'default'">
       <input class="form-control" type="{{currentField?.type}}" [(ngModel)]="currentValue"
              placeholder="{{currentField?.placeholder}}"
+             [disabled]="config.disabled === true"
              (keypress)="fieldInputKeyPress($event)"/>
     </div>
     <div *ngIf="currentField?.type === 'select'">
       <div class="btn-group bootstrap-select form-control filter-select" dropdown>
-        <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle>
+        <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
+                [disabled]="config.disabled === true">
           <span class="filter-option pull-left">{{currentValue || currentField?.placeholder}}</span>
           <span class="caret"></span>
         </button>
@@ -49,8 +52,17 @@
       </div>
     </div>
     <div *ngIf="currentField?.type === 'typeahead'">
+      <div class="btn-group bootstrap-select form-control filter-select"
+           *ngIf="config.disabled === true">
+        <div class="pull-left typeahead-input-container disabled">
+          <input class="form-control" type="text" placeholder="{{currentField?.placeholder}}"
+                 [disabled]="config.disabled === true">
+          <span class="caret"></span>
+        </div>
+      </div>
       <div class="btn-group bootstrap-select form-control filter-select" dropdown
-           (isOpenChange)="hideDeleteConfirm($event)">
+           (isOpenChange)="hideDeleteConfirm($event)"
+           *ngIf="config.disabled !== true">
         <div class="pull-left typeahead-input-container dropdown-toggle" dropdownToggle>
           <input #queryInput class="form-control" type="text" placeholder="{{currentField?.placeholder}}"
                  [(ngModel)]="currentValue"

--- a/src/app/filter/filter-fields.component.less
+++ b/src/app/filter/filter-fields.component.less
@@ -11,6 +11,12 @@
       white-space: nowrap;
     }
     .typeahead-input-container {
+      &.disabled {
+        width: 100%;
+        .caret {
+          top: 8px;
+        }
+      }
       position: relative;
       padding-right: 0;
       .caret {

--- a/src/app/filter/filter-fields.component.ts
+++ b/src/app/filter/filter-fields.component.ts
@@ -52,7 +52,9 @@ export class FilterFieldsComponent implements DoCheck, OnInit {
 
   private _currentField: FilterField;
   private _currentValue: string;
-  private defaultConfig = {} as FilterConfig;
+  private defaultConfig = {
+    disabled: false
+  } as FilterConfig;
   private prevConfig: FilterConfig;
 
   /**

--- a/src/app/filter/filter-results.component.html
+++ b/src/app/filter/filter-results.component.html
@@ -8,12 +8,16 @@
         <li *ngFor="let filter of config.appliedFilters">
           <span class="active-filter label label-info">
             {{filter.field.title}}: {{filter.value}}
-            <span class="margin-left-5 pficon pficon-close" (click)="clearFilter(filter)"></span>
+            <span class="margin-left-5 pficon pficon-close"
+                  (click)="clearFilter(filter)"
+                  *ngIf="config.disabled !== true"></span>
           </span>
         </li>
       </ul>
       <p>
-        <a class="clear-filters" (click)="clearAllFilters()"
+        <a class="clear-filters" href="javascript:void(0)"
+           [class.disabled]="config.disabled === true"
+           (click)="config.disabled !== true && clearAllFilters()"
            *ngIf="config.appliedFilters.length > 0">Clear All Filters</a>
       </p>
       <p class="pfng-save-filter margin-left-10">
@@ -37,8 +41,11 @@
           </div>
         </ng-template>
         <span placement="bottom" [popover]="saveFilterTemplate" #saveFilterPop="bs-popover">
-          <a *ngIf="config.showSaveFilter">Save Filter</a>
+          <a *ngIf="config.showSaveFilter && config.disabled !== true">Save Filter</a>
         </span>
+        <a href="javascript:void(0)"
+           [class.disabled]="config.disabled === true"
+           *ngIf="config.showSaveFilter && config.disabled === true">Save Filter</a>
       </p>
     </div>
     <div class="col-sm-3 table-view-pf-select-results" *ngIf="config.totalCount > 0">

--- a/src/app/filter/filter-results.component.ts
+++ b/src/app/filter/filter-results.component.ts
@@ -39,7 +39,9 @@ export class FilterResultsComponent implements DoCheck, OnInit {
    */
   @Output('onSave') onSave = new EventEmitter();
 
-  private defaultConfig = {} as FilterConfig;
+  private defaultConfig = {
+    disabled: false
+  } as FilterConfig;
   private prevConfig: FilterConfig;
   private saveFilterName: string;
 

--- a/src/app/filter/filter.component.ts
+++ b/src/app/filter/filter.component.ts
@@ -62,7 +62,9 @@ export class FilterComponent implements DoCheck, OnInit {
    */
   @ViewChild('filterFields') private filterFields: FilterFieldsComponent;
 
-  private defaultConfig = {} as FilterConfig;
+  private defaultConfig = {
+    disabled: false
+  } as FilterConfig;
   private prevConfig: FilterConfig;
 
   /**

--- a/src/app/notification/examples/inline-notification-example.component.html
+++ b/src/app/notification/examples/inline-notification-example.component.html
@@ -74,15 +74,15 @@
         </div>
       </form>
     </div>
-    <div class="row padding-bottom-15 padding-top-15">
-      <div class="col-sm-12">
-        <h4 class="actions-label">Actions</h4>
-        <hr/>
-      </div>
-    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
-      <textarea rows="3" class="col-sm-12">{{actionText}}</textarea>
+      <h4 class="actions-label">Actions</h4>
+      <hr/>
     </div>
+  </div>
+  <div class="col-sm-12">
+    <textarea rows="3" class="col-sm-12">{{actionText}}</textarea>
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">

--- a/src/app/notification/examples/toast-notification-example.component.html
+++ b/src/app/notification/examples/toast-notification-example.component.html
@@ -83,15 +83,15 @@
         </div>
       </form>
     </div>
-    <div class="row padding-bottom-15 padding-top-15">
-      <div class="col-sm-12">
-        <h4 class="actions-label">Actions</h4>
-        <hr/>
-      </div>
-    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
-      <textarea rows="3" class="col-sm-12">{{actionText}}</textarea>
+      <h4 class="actions-label">Actions</h4>
+      <hr/>
     </div>
+  </div>
+  <div class="col-sm-12">
+    <textarea rows="3" class="col-sm-12">{{actionText}}</textarea>
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">

--- a/src/app/remaining-chars-count/examples/remaining-chars-count-example.component.html
+++ b/src/app/remaining-chars-count/examples/remaining-chars-count-example.component.html
@@ -1,13 +1,12 @@
 <div class="padding-15">
-<div class="padding-15">
-  <div class="row padding-bottom-15">
+  <div class="row">
     <div class="col-sm-12">
       <h4>Remaining Chars Directive Example</h4>
       <hr/>
     </div>
   </div>
   <div class="example-container">
-    <h3>Max limit: 20, warn when 5 or less remaining, disable button after max limit</h3>
+    <h4>Max limit: 20, warn when 5 or less remaining, disable button after max limit</h4>
     <div class="row">
       <div class="col-sm-4">
         <div class="form-group">
@@ -29,7 +28,7 @@
       </span>
       </div>
     </div>
-    <h3>Max limit: 10, warn when 2 or less remaining, block input after max limit</h3>
+    <h4>Max limit: 10, warn when 2 or less remaining, block input after max limit</h4>
     <div class="row">
       <div class="col-sm-4">
         <form>
@@ -55,7 +54,7 @@
         </form>
       </div>
     </div>
-    <h3>Max limit: 10, warn when 5 or less remaining, block input after max limit</h3>
+    <h4>Max limit: 10, warn when 5 or less remaining, block input after max limit</h4>
     <div class="row">
       <div class="col-sm-4">
         <label class="sr-only" for="example3">Example 3</label>

--- a/src/app/sort/examples/sort-example.component.html
+++ b/src/app/sort/examples/sort-example.component.html
@@ -37,6 +37,24 @@
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="disabled" name="disabled" type="checkbox"
+                   [(ngModel)]="sortConfig.disabled">Disabled
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-sm-12">
       <h4>Code</h4>
       <hr/>
     </div>

--- a/src/app/sort/sort-config.ts
+++ b/src/app/sort/sort-config.ts
@@ -5,6 +5,11 @@ import { SortField } from './sort-field';
  */
 export class SortConfig {
   /**
+   * A flag indicating the component is disabled
+   */
+  disabled?: boolean;
+
+  /**
    * A list of sortable fields
    */
   fields: SortField[];

--- a/src/app/sort/sort.component.html
+++ b/src/app/sort/sort.component.html
@@ -1,6 +1,7 @@
 <div class="sort-pf" *ngIf="config?.visible !== false">
   <div class="btn-group dropdown" dropdown>
-    <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle>
+    <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
+            [disabled]="config.disabled === true">
       {{currentField?.title}}
       <span class="caret"></span>
     </button>
@@ -11,7 +12,9 @@
       </li>
     </ul>
   </div>
-  <button class="btn btn-link" type="button" (click)="onChangeDirection()">
+  <button class="btn btn-link" type="button"
+          [disabled]="config.disabled === true"
+          (click)="onChangeDirection()">
     <span class="sort-direction" [ngClass]="getIconStyleClass()"></span>
   </button>
 </div>

--- a/src/app/toolbar/examples/toolbar-example.component.html
+++ b/src/app/toolbar/examples/toolbar-example.component.html
@@ -84,6 +84,24 @@
   </div>
   <div class="row padding-bottom-15 padding-top-15">
     <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="disabled" name="disabled" type="checkbox"
+                   [(ngModel)]="toolbarConfig.disabled">Disabled
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row padding-bottom-15 padding-top-15">
+    <div class="col-sm-12">
       <h4 class="actions-label">Actions</h4>
       <hr/>
     </div>

--- a/src/app/toolbar/examples/toolbar-example.module.ts
+++ b/src/app/toolbar/examples/toolbar-example.module.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -18,6 +19,7 @@ import { ToolbarModule } from '../toolbar.module';
     CommonModule,
     DemoComponentsModule,
     FilterModule,
+    FormsModule,
     TabsModule.forRoot(),
     ToolbarModule
   ],

--- a/src/app/toolbar/toolbar-config.ts
+++ b/src/app/toolbar/toolbar-config.ts
@@ -13,6 +13,13 @@ export class ToolbarConfig {
   actionConfig?: ActionConfig;
 
   /**
+   * A flag indicating the component is disabled
+   *
+   * Note: This will not disable components within your custom action and view templates
+   */
+  disabled?: boolean;
+
+  /**
    * Config properties for toolbar filter. If undefined, filter features are not shown.
    */
   filterConfig?: FilterConfig;

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -82,7 +82,9 @@ export class ToolbarComponent implements DoCheck, OnInit {
 
   @ViewChild('filterFields') private filterFields: FilterFieldsComponent;
 
-  private defaultConfig: ToolbarConfig = {} as ToolbarConfig;
+  private defaultConfig: ToolbarConfig = {
+    disabled: false
+  } as ToolbarConfig;
   private prevConfig: ToolbarConfig;
 
   /**
@@ -120,12 +122,17 @@ export class ToolbarComponent implements DoCheck, OnInit {
       this.config = cloneDeep(this.defaultConfig);
     }
 
-    if (this.config && this.config.filterConfig
-        && this.config.filterConfig.appliedFilters === undefined) {
-      this.config.filterConfig.appliedFilters = [];
+    if (this.config && this.config.filterConfig) {
+      this.config.filterConfig.disabled = this.config.disabled;
+      if (this.config.filterConfig.appliedFilters === undefined) {
+        this.config.filterConfig.appliedFilters = [];
+      }
     }
-    if (this.config && this.config.sortConfig && this.config.sortConfig.fields === undefined) {
-      this.config.sortConfig.fields = [];
+    if (this.config && this.config.sortConfig) {
+      this.config.sortConfig.disabled = this.config.disabled;
+      if (this.config.sortConfig.fields === undefined) {
+        this.config.sortConfig.fields = [];
+      }
     }
     if (this.config.sortConfig !== undefined && this.config.sortConfig.visible === undefined) {
       this.config.sortConfig.visible = true;


### PR DESCRIPTION
When the datatable has no data to display, toolbar actions (filter and sort) must be disabled. This PR adds a disabled state for the filter, sort, and toolbar components to support datatable.

https://rawgit.com/dlabrecq/patternfly-ng/disabled-dist/dist-demo/#/toolbar