### PR TITLE
Updated patternfly-eng-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "nsp": "2.7.0",
     "optimize-js-plugin": "0.0.4",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "3.26.51",
+    "patternfly-eng-release": "3.26.54",
     "phantomjs-prebuilt": "2.1.14",
     "protractor": "5.1.1",
     "raw-loader": "0.5.1",


### PR DESCRIPTION
Changed patternfly-eng-release script to not run the build:demo target as the main build already runs it. Travis will complete much faster if we don’t run the build twice.