### PR TITLE
fix(sparkline): avoid regenerating chart on every data update

### DIFF
--- a/src/app/chart/sparkline/sparkline.component.ts
+++ b/src/app/chart/sparkline/sparkline.component.ts
@@ -60,9 +60,10 @@ export class SparklineComponent extends ChartBase implements DoCheck, OnInit {
    * Check if the component config has changed
    */
   ngDoCheck(): void {
-    if (!isEqual(this.config, this.prevConfig) || !isEqual(this.chartData, this.prevChartData)) {
+    const dataChanged = !isEqual(this.chartData, this.prevChartData);
+    if (dataChanged || !isEqual(this.config, this.prevConfig)) {
       this.setupConfig();
-      this.generateChart(this.config, true);
+      this.generateChart(this.config, !dataChanged);
     }
   }
 


### PR DESCRIPTION
When only chart data has changed and config remains unchanged, the sparkline chart component will
not be regenerated but the data simply reloaded instead. This should be a lighter-weight operation
and avoids a visual flicker and redraw of the chart component on data update.

fixes https://github.com/patternfly/patternfly-ng/issues/275