### PR TITLE
Donut chart: avoid regenerating chart on every data update

### DIFF
--- a/src/app/chart/donut/donut.component.ts
+++ b/src/app/chart/donut/donut.component.ts
@@ -73,9 +73,10 @@ export class DonutComponent extends ChartBase implements DoCheck, OnDestroy, OnI
    * Check if the component config has changed
    */
   ngDoCheck(): void {
-    if (!isEqual(this.config, this.prevConfig) || !isEqual(this.chartData, this.prevChartData)) {
+    const dataChanged = !isEqual(this.chartData, this.prevChartData);
+    if (dataChanged || !isEqual(this.config, this.prevConfig)) {
       this.setupConfig();
-      this.generateChart(this.config, true);
+      this.generateChart(this.config, !dataChanged);
     }
   }
 


### PR DESCRIPTION
Duplicating the sparkline fix (#276) for donut chart to smooth out the animation when transitioning between data sets -- best seen with the dynamic example.

https://rawgit.com/dlabrecq/patternfly-ng/donut-dist/dist-demo/#/donut

"When only chart data has changed and config remains unchanged, the sparkline chart component will not be regenerated but the data simply reloaded instead. This should be a lighter-weight operation and avoids a visual flicker and redraw of the chart component on data update."