### PR TITLE
chore(card-tests): remove unnecessary statements in unit test

### DIFF
--- a/src/app/card/basic-card/card.component.spec.ts
+++ b/src/app/card/basic-card/card.component.spec.ts
@@ -138,9 +138,8 @@ describe('Card component - ', () => {
 
     let button = element.querySelector('.card-pf-time-frame-filter .dropdown-toggle');
     button.click();
-    fixture.detectChanges(); // Workaround to fix dropdown tests
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
 
     let elements = element.querySelectorAll('.card-pf-time-frame-filter .dropdown-item');
     expect(elements.length).toBe(3);


### PR DESCRIPTION
for card component

when relying on tick to simulate passage of time, we only need
to call fixture.detectChanges() after the tick() statement

tested with ngx-bootstrap v1.8.0 and 1.9.3