### PR TITLE
chore(filter-tests): remove unnecessary statements in unit test

### DIFF
--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -146,9 +146,8 @@ describe('Filter component - ', () => {
 
     let button = element.querySelector('.filter-pf button');
     button.click();
-    fixture.detectChanges(); // Workaround to fix dropdown tests
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
 
     let fields = element.querySelectorAll('.filter-field');
     expect(fields.length).toBe(5);
@@ -201,9 +200,8 @@ describe('Filter component - ', () => {
 
     let button = element.querySelector('.filter-pf button');
     button.click();
-    fixture.detectChanges(); // Workaround to fix dropdown tests
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
 
     let filterSelect = element.querySelector('.filter-select');
     let fields = element.querySelectorAll('.filter-field');


### PR DESCRIPTION
when relying on tick to simulate passage of time, we only need
to call fixture.detectChanges() after the tick() statement

tested with ngx-bootstrap v1.8.0 and 1.9.3