### PR TITLE
chore(pagination-tests): remove unnecessary statements in unit test

### DIFF
--- a/src/app/pagination/pagination.component.spec.ts
+++ b/src/app/pagination/pagination.component.spec.ts
@@ -71,9 +71,8 @@ describe('Pagination component - ', () => {
 
     let button = element.querySelector('button');
     button.click();
-    fixture.detectChanges(); // Workaround to fix dropdown tests
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
 
     expect(element.querySelector('[dropdown]').classList).toContain('open');
 
@@ -81,7 +80,7 @@ describe('Pagination component - ', () => {
     let item = element.querySelectorAll('ul.dropdown-menu > li > a');
     item[2].click();
     fixture.detectChanges();
-    
+
     expect(element.querySelector('[dropdown]').classList).not.toContain('open');
     expect(comp.config.pageSize).toEqual(20);
   }));


### PR DESCRIPTION
when relying on tick to simulate passage of time, we only need
to call fixture.detectChanges() after the tick() statement

tested with ngx-bootstrap v1.8.0 and 1.9.3