### PR TITLE
Tests: use headless chrome instead of PhantomJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
   directories:
     - node_modules
 
+addons:
+  chrome: stable
+  
 notifications:
   email: false
 
@@ -18,6 +21,9 @@ env:
 
 before_install:
   - npm install patternfly-eng-release
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 install: true
 

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -78,7 +78,6 @@ module.exports = function(config) {
      * start these browsers
      * available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
      */
-/*
     browsers: [
       'Chrome'
     ],
@@ -89,7 +88,7 @@ module.exports = function(config) {
         flags: ['--no-sandbox']
       }
     },
-*/
+/*
     browsers: ['PhantomJS_custom'],
     customLaunchers: {
       'PhantomJS_custom': {
@@ -109,19 +108,17 @@ module.exports = function(config) {
       // (useful if karma exits without killing phantom)
       exitOnResourceError: true
     },
-
+*/
     /*
      * Continuous Integration mode
      * if true, Karma captures browsers, runs the tests and exits
      */
     singleRun: true
   };
-/*
+
   if (process.env.TRAVIS){
-    configuration.browsers = [
-      'ChromeTravisCi'
-    ];
+    configuration.browsers = ['ChromeTravisCi'];
   }
-*/
+
   config.set(configuration);
 };

--- a/src/app/list/tree-list/tree-list.component.spec.ts
+++ b/src/app/list/tree-list/tree-list.component.spec.ts
@@ -134,27 +134,26 @@ describe('Tree List component - ', () => {
    * ERROR: '[mobx] Encountered an uncaught exception that was thrown by a reaction or observer
    * component, in: 'Reaction[Autorun@175]'
    *
-   * This appears related to:
-   * https://angular2-tree.readme.io/v2.2.0/discuss/58b936ad759c201900abfdb5
-   *
-   * Update:
    * Apparently there are no plans to make angular-tree-component work with PhantomJS
    * See: https://github.com/500tech/angular-tree-component/issues/433
    *
    * "Best to shift to a more modern headless browser and not invest your time in issues with Phantom"
+   *
+   * Also see:
+   * https://angular2-tree.readme.io/v2.2.0/discuss/58b936ad759c201900abfdb5
    */
 
-   xit('Should have at least one node', function() {
+   it('Should have at least one node', function() {
      let elements = fixture.debugElement.queryAll(By.css('.tree-node'));
      expect(elements.length).toBe(4);
    });
   
-   xit('Should have collapsed toggle', function() {
+   it('Should have collapsed toggle', function() {
      let elements = fixture.debugElement.queryAll(By.css('.tree-node-collapsed'));
      expect(elements.length).toBe(1);
    });
   
-   xit('Should have expanded toggle', function() {
+   it('Should have expanded toggle', function() {
      let elements = fixture.debugElement.queryAll(By.css('.tree-node-expanded'));
      expect(elements.length).toBe(1);
    });

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.spec.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.spec.ts
@@ -15,185 +15,188 @@ import { WindowReference } from '../../utilities/window.reference';
 describe('Vertical Navigation component - ', () => {
   let comp: VerticalNavigationComponent;
   let fixture: ComponentFixture<VerticalNavigationComponent>;
-  let navigationItems: NavigationItemConfig[] = [
-    {
-      title: 'Dashboard',
-      iconStyleClass: 'fa fa-dashboard',
-      url: '#/dashboard'
-    },
-    {
-      title: 'Dolor',
-      iconStyleClass: 'fa fa-shield',
-      url: '#/dolor',
-      badges: [
-        {
-          count: 1283,
-          tooltip: 'Total number of items'
-        }
-      ]
-    },
-    {
-      title: 'Ipsum',
-      iconStyleClass: 'fa fa-space-shuttle',
-      activeOnLoad: true,
-      children: [
-        {
-          title: 'Intellegam',
-          activeOnLoad: true,
-          children: [
-            {
-              title: 'Recteque',
-              url: '#/ipsum/intellegam/recteque',
-              badges: [
-                {
-                  count: 6,
-                  tooltip: 'Total number of error items',
-                  badgeClass: 'example-error-background'
-                }
-              ]
-            },
-            {
-              title: 'Suavitate',
-              url: '#/ipsum/intellegam/suavitate',
-              badges: [
-                {
-                  count: 0,
-                  tooltip: 'Total number of items',
-                  badgeClass: 'example-ok-background'
-                }
-              ]
-            },
-            {
-              title: 'Vituperatoribus',
-              url: '#/ipsum/intellegam/vituperatoribus',
-              badges: [
-                {
-                  count: 18,
-                  tooltip: 'Total number of warning items',
-                  badgeClass: 'example-warning-background'
-                }
-              ]
-            }
-          ]
-        },
-        {
-          title: 'Copiosae',
-          children: [
-            {
-              title: 'Exerci',
-              url: '#/ipsum/copiosae/exerci'
-            },
-            {
-              title: 'Quaeque',
-              url: '#/ipsum/copiosae/quaeque'
-            },
-            {
-              title: 'Utroque',
-              url: '#/ipsum/copiosae/utroque'
-            }
-          ]
-        },
-        {
-          title: 'Patrioque',
-          children: [
-            {
-              title: 'Novum',
-              url: '#/ipsum/patrioque/novum'
-            },
-            {
-              title: 'Pericula',
-              url: '#/ipsum/patrioque/pericula'
-            },
-            {
-              title: 'Gubergren',
-              url: '#/ipsum/patrioque/gubergren'
-            }
-          ]
-        },
-        {
-          title: 'Accumsan',
-          url: '#/ipsum/Accumsan'
-        }
-      ]
-    },
-    {
-      title: 'Amet',
-      iconStyleClass: 'fa fa-paper-plane',
-      children: [
-        {
-          title: 'Detracto',
-          children: [
-            {
-              title: 'Delicatissimi',
-              url: '#/amet/detracto/delicatissimi'
-            },
-            {
-              title: 'Aliquam',
-              url: '#/amet/detracto/aliquam'
-            },
-            {
-              title: 'Principes',
-              url: '#/amet/detracto/principes'
-            }
-          ]
-        },
-        {
-          title: 'Mediocrem',
-          children: [
-            {
-              title: 'Convenire',
-              url: '#/amet/mediocrem/convenire'
-            },
-            {
-              title: 'Nonumy',
-              url: '#/amet/mediocrem/nonumy'
-            },
-            {
-              title: 'Deserunt',
-              url: '#/amet/mediocrem/deserunt'
-            }
-          ]
-        },
-        {
-          title: 'Corrumpit',
-          children: [
-            {
-              title: 'Aeque',
-              url: '#/amet/corrumpit/aeque'
-            },
-            {
-              title: 'Delenit',
-              url: '#/amet/corrumpit/delenit'
-            },
-            {
-              title: 'Qualisque',
-              url: '#/amet/corrumpit/qualisque'
-            }
-          ]
-        },
-        {
-          title: 'urbanitas',
-          url: '#/amet/urbanitas'
-        }
-      ]
-    },
-    {
-      title: 'Adipscing',
-      iconStyleClass: 'fa fa-graduation-cap',
-      url: '#/adipscing'
-    },
-    {
-      title: 'Lorem',
-      iconStyleClass: 'fa fa-gamepad',
-      url: '#/lorem'
-    }
-  ];
-
+  let navigationItems: NavigationItemConfig[];
   let navigateItem, clickItem;
 
-  beforeEach(async(() => {
-    navigateItem = undefined;
+  beforeEach(() => {
     clickItem = undefined;
+    navigateItem = undefined;
+    navigationItems = [
+      {
+        title: 'Dashboard',
+        iconStyleClass: 'fa fa-dashboard',
+        url: '#/dashboard'
+      },
+      {
+        title: 'Dolor',
+        iconStyleClass: 'fa fa-shield',
+        url: '#/dolor',
+        badges: [
+          {
+            count: 1283,
+            tooltip: 'Total number of items'
+          }
+        ]
+      },
+      {
+        title: 'Ipsum',
+        iconStyleClass: 'fa fa-space-shuttle',
+        activeOnLoad: true,
+        children: [
+          {
+            title: 'Intellegam',
+            activeOnLoad: true,
+            children: [
+              {
+                title: 'Recteque',
+                url: '#/ipsum/intellegam/recteque',
+                badges: [
+                  {
+                    count: 6,
+                    tooltip: 'Total number of error items',
+                    badgeClass: 'example-error-background'
+                  }
+                ]
+              },
+              {
+                title: 'Suavitate',
+                url: '#/ipsum/intellegam/suavitate',
+                badges: [
+                  {
+                    count: 0,
+                    tooltip: 'Total number of items',
+                    badgeClass: 'example-ok-background'
+                  }
+                ]
+              },
+              {
+                title: 'Vituperatoribus',
+                url: '#/ipsum/intellegam/vituperatoribus',
+                badges: [
+                  {
+                    count: 18,
+                    tooltip: 'Total number of warning items',
+                    badgeClass: 'example-warning-background'
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            title: 'Copiosae',
+            children: [
+              {
+                title: 'Exerci',
+                url: '#/ipsum/copiosae/exerci'
+              },
+              {
+                title: 'Quaeque',
+                url: '#/ipsum/copiosae/quaeque'
+              },
+              {
+                title: 'Utroque',
+                url: '#/ipsum/copiosae/utroque'
+              }
+            ]
+          },
+          {
+            title: 'Patrioque',
+            children: [
+              {
+                title: 'Novum',
+                url: '#/ipsum/patrioque/novum'
+              },
+              {
+                title: 'Pericula',
+                url: '#/ipsum/patrioque/pericula'
+              },
+              {
+                title: 'Gubergren',
+                url: '#/ipsum/patrioque/gubergren'
+              }
+            ]
+          },
+          {
+            title: 'Accumsan',
+            url: '#/ipsum/Accumsan'
+          }
+        ]
+      },
+      {
+        title: 'Amet',
+        iconStyleClass: 'fa fa-paper-plane',
+        children: [
+          {
+            title: 'Detracto',
+            children: [
+              {
+                title: 'Delicatissimi',
+                url: '#/amet/detracto/delicatissimi'
+              },
+              {
+                title: 'Aliquam',
+                url: '#/amet/detracto/aliquam'
+              },
+              {
+                title: 'Principes',
+                url: '#/amet/detracto/principes'
+              }
+            ]
+          },
+          {
+            title: 'Mediocrem',
+            children: [
+              {
+                title: 'Convenire',
+                url: '#/amet/mediocrem/convenire'
+              },
+              {
+                title: 'Nonumy',
+                url: '#/amet/mediocrem/nonumy'
+              },
+              {
+                title: 'Deserunt',
+                url: '#/amet/mediocrem/deserunt'
+              }
+            ]
+          },
+          {
+            title: 'Corrumpit',
+            children: [
+              {
+                title: 'Aeque',
+                url: '#/amet/corrumpit/aeque'
+              },
+              {
+                title: 'Delenit',
+                url: '#/amet/corrumpit/delenit'
+              },
+              {
+                title: 'Qualisque',
+                url: '#/amet/corrumpit/qualisque'
+              }
+            ]
+          },
+          {
+            title: 'urbanitas',
+            url: '#/amet/urbanitas'
+          }
+        ]
+      },
+      {
+        title: 'Adipscing',
+        iconStyleClass: 'fa fa-graduation-cap',
+        url: '#/adipscing'
+      },
+      {
+        title: 'Lorem',
+        iconStyleClass: 'fa fa-gamepad',
+        url: '#/lorem'
+      }
+    ];
+  });
+
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, TooltipModule.forRoot(), RouterTestingModule],
       declarations: [VerticalNavigationComponent],

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
@@ -200,8 +200,12 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * Destroy listeners
    */
   ngOnDestroy() {
-    this.routeChangeListener.unsubscribe();
-    this.windowRef.nativeWindow.removeEventListener('resize');
+    if (this.routeChangeListener !== undefined) {
+      this.routeChangeListener.unsubscribe();
+    }
+    if (this.windowListener !== undefined) {
+      this.windowRef.nativeWindow.removeEventListener('resize', this.windowListener);
+    }
   }
 
   // Actions


### PR DESCRIPTION
Using headless chrome instead of PhantomJS to finally enable tree-list tests.

Also fixed errors generated during each test cleanup phase, due to window listeners not being destroyed properly.