### PR TITLE
Bump ngx-bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,14 +67,14 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "ngx-bootstrap": "^1.8.0",
     "patternfly": "^3.28.0"
   },
   "optionalDependencies": {
     "@swimlane/ngx-datatable": "^11.1.7",
     "angular-tree-component": "^6.0.0",
     "c3": "^0.4.15",
-    "ng2-dragula": "^1.5.0"
+    "ng2-dragula": "^1.5.0",
+    "ngx-bootstrap": "^2.0.0"
   },
   "devDependencies": {
     "@angular/animations": "^4.0.1",

--- a/src/app/modal/example/about-modal-example.component.ts
+++ b/src/app/modal/example/about-modal-example.component.ts
@@ -7,8 +7,8 @@ import {
 } from '@angular/core';
 
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { BsModalRef } from 'ngx-bootstrap/modal/modal-options.class'; // BS 1.8.0
-// import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service'; // BS 2.0.0-beta
+// import { BsModalRef } from 'ngx-bootstrap/modal/modal-options.class'; // BS 1.8.0
+import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service'; // BS 2.0.0-beta
 import { AboutModalConfig } from '../about-modal-config';
 import { AboutModalEvent } from '../about-modal-event';
 

--- a/src/app/wizard/example/wizard-example.component.ts
+++ b/src/app/wizard/example/wizard-example.component.ts
@@ -7,8 +7,8 @@ import {
 } from '@angular/core';
 
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { BsModalRef } from 'ngx-bootstrap/modal/modal-options.class'; // BS 1.8.0
-// import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service'; // BS 2.0.0-beta
+// import { BsModalRef } from 'ngx-bootstrap/modal/modal-options.class'; // BS 1.8.0
+import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service'; // BS 2.0.0-beta
 import { TabDirective } from 'ngx-bootstrap/tabs';
 
 import { WizardEvent } from '../wizard-event';


### PR DESCRIPTION
Bumped ngx-bootstrap to v2.0.0 and made it an optional dependency.

Not all patternfly-ng modules require ngx-bootstrap (e.g., chart, empty state, about modal, remaining-chars, and pipes). Packages such as ngx-datatable, angular-tree-component, c3, and ng2-dragula are already defined as optional dependencies.

Tested with OSIO, which still uses ngx-bootstrap v1.8.0.