### PR TITLE
chore(deps): use flexible range for ngx-bootstrap dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "ngx-bootstrap": "1.8.0",
+    "ngx-bootstrap": "^1.8.0",
     "patternfly": "^3.28.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR is an incremental step toward supporting latest version of ngx-bootstrap.

This helps https://github.com/patternfly/patternfly-ng/issues/279

Further progress has been made on this front on https://github.com/patternfly/patternfly-ng/pull/302, however testing is still underway for that PR as it also moves this library into the optional dependencies and utilizes the recently released 2.x. This PR is merely a stepping stone toward that same goal.