### PR TITLE
Bump angular-tree-component version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "optionalDependencies": {
     "@swimlane/ngx-datatable": "^11.1.7",
-    "angular-tree-component": "^6.0.0",
+    "angular-tree-component": "^7.0.0",
     "c3": "^0.4.15",
     "ng2-dragula": "^1.5.0"
   },


### PR DESCRIPTION
Bumped angular-tree-component to v7.0.0 for latest fixes.