### PR TITLE
Table: expose ngx-datatable sort event

### DIFF
--- a/src/app/table/basic-table/example/table-embedded-example.component.ts
+++ b/src/app/table/basic-table/example/table-embedded-example.component.ts
@@ -94,25 +94,29 @@ export class TableEmbeddedExampleComponent implements AfterViewInit, OnInit {
       draggable: true,
       prop: 'name',
       name: 'Name',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.addressTemplate,
       draggable: true,
       prop: 'address',
       name: 'Address',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.birthMonthTemplate,
       draggable: true,
       prop: 'birthMonth',
       name: 'Birth Month',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.weekDayTemplate,
       draggable: true,
       prop: 'weekDay',
       name: 'Week Day',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }];
 
     this.allRows = [{
@@ -536,7 +540,7 @@ export class TableEmbeddedExampleComponent implements AfterViewInit, OnInit {
     this.currentSortField = $event.field;
     this.isAscendingSort = $event.isAscending;
     this.allRows.sort((item1: any, item2: any) => this.compare(item1, item2));
-    this.updateRows(false);
+    this.applyFilters(this.filterConfig.appliedFilters || []);
   }
 
   // Selection

--- a/src/app/table/basic-table/example/table-full-example.component.html
+++ b/src/app/table/basic-table/example/table-full-example.component.html
@@ -8,6 +8,7 @@
             [actionTemplate]="actionTemplate"
             [columns]="columns"
             [config]="tableConfig"
+            [dataTableConfig]="dataTableConfig"
             [expandRowTemplate]="expandRowTemplate"
             [rows]="rows"
             (onActivate)="handleOnActivate($event)"
@@ -22,7 +23,8 @@
             (onResize)="handleOnResize($event)"
             (onScroll)="handleOnScroll($event)"
             (onSelectionChange)="handleSelectionChange($event)"
-            (onSortChange)="handleSortChanged($event)">
+            (onSortChange)="handleSortChanged($event)"
+            (onSort)="handleSort($event)">
         </pfng-table>
         <!-- Column templates -->
         <ng-template #nameTemplate let-row="row">

--- a/src/app/table/basic-table/example/table-full-example.component.ts
+++ b/src/app/table/basic-table/example/table-full-example.component.ts
@@ -15,6 +15,7 @@ import { FilterConfig } from '../../../filter/filter-config';
 import { FilterField } from '../../../filter/filter-field';
 import { FilterEvent } from '../../../filter/filter-event';
 import { FilterType } from '../../../filter/filter-type';
+import { NgxDataTableConfig } from '../ngx-datatable-config';
 import { PaginationConfig } from '../../../pagination/pagination-config';
 import { PaginationEvent } from '../../../pagination/pagination-event';
 import { SortConfig } from '../../../sort/sort-config';
@@ -43,7 +44,7 @@ export class TableFullExampleComponent implements AfterViewInit, OnInit {
   allRows: any[];
   columns: any[];
   currentSortField: SortField;
-  tableConfig: TableConfig;
+  dataTableConfig: NgxDataTableConfig;
   emptyStateConfig: EmptyStateConfig;
   filterConfig: FilterConfig;
   filteredRows: any[];
@@ -54,6 +55,7 @@ export class TableFullExampleComponent implements AfterViewInit, OnInit {
   rowsAvailable: boolean = true;
   separator: Object;
   sortConfig: SortConfig;
+  tableConfig: TableConfig;
   toolbarConfig: ToolbarConfig;
   weekDayQueries: any[];
 
@@ -365,6 +367,10 @@ export class TableFullExampleComponent implements AfterViewInit, OnInit {
       toolbarConfig: this.toolbarConfig,
       useExpandRows: true
     } as TableConfig;
+
+    this.dataTableConfig = {
+      externalSorting: true
+    };
   }
 
   // Actions
@@ -516,19 +522,19 @@ export class TableFullExampleComponent implements AfterViewInit, OnInit {
 
   // Sort
 
-  compare(item1: any, item2: any): number {
+  compare(item1: any, item2: any, id: string, ascending: boolean): number {
     let compValue = 0;
-    if (this.currentSortField.id === 'name') {
+    if (id === 'name') {
       compValue = item1.name.localeCompare(item2.name);
-    } else if (this.currentSortField.id === 'address') {
+    } else if (id === 'address') {
       compValue = item1.address.localeCompare(item2.address);
-    } else if (this.currentSortField.id === 'birthMonth') {
+    } else if (id === 'birthMonth') {
       compValue = this.monthVals[item1.birthMonth] - this.monthVals[item2.birthMonth];
-    } else if (this.currentSortField.id === 'weekDay') {
+    } else if (id === 'weekDay') {
       compValue = this.weekDayVals[item1.weekDay] - this.weekDayVals[item2.weekDay];
     }
 
-    if (!this.isAscendingSort) {
+    if (!ascending) {
       compValue = compValue * -1;
     }
     return compValue;
@@ -538,8 +544,18 @@ export class TableFullExampleComponent implements AfterViewInit, OnInit {
   handleSortChanged($event: SortEvent): void {
     this.currentSortField = $event.field;
     this.isAscendingSort = $event.isAscending;
-    this.allRows.sort((item1: any, item2: any) => this.compare(item1, item2));
-    this.updateRows(false);
+    this.allRows.sort((item1: any, item2: any) =>
+      this.compare(item1, item2, this.currentSortField.id, this.isAscendingSort));
+    this.applyFilters(this.filterConfig.appliedFilters || []);
+  }
+
+  // Handle ngx-datatable sort via column header
+  handleSort($event: any): void {
+    $event.sorts.forEach((sort: any) => {
+      this.allRows.sort((item1: any, item2: any) =>
+        this.compare(item1, item2, sort.prop, (sort.dir === 'asc')));
+    });
+    this.applyFilters(this.filterConfig.appliedFilters || []);
   }
 
   // Selection

--- a/src/app/table/basic-table/example/table-group-example.component.ts
+++ b/src/app/table/basic-table/example/table-group-example.component.ts
@@ -38,25 +38,29 @@ export class TableGroupExampleComponent implements OnInit {
       draggable: true,
       prop: 'name',
       name: 'Name',
-      resizeable: true
+      resizeable: true,
+      sortable: false // n/a with group header
     }, {
       cellTemplate: this.addressTemplate,
       draggable: true,
       prop: 'address',
       name: 'Address',
-      resizeable: true
+      resizeable: true,
+      sortable: false // n/a with group header
     }, {
       cellTemplate: this.birthMonthTemplate,
       draggable: true,
       prop: 'birthMonth',
       name: 'Birth Month',
-      resizeable: true
+      resizeable: true,
+      sortable: false // n/a with group header
     }, {
       cellTemplate: this.weekDayTemplate,
       draggable: true,
       prop: 'weekDay',
       name: 'Week Day',
-      resizeable: true
+      resizeable: true,
+      sortable: false // n/a with group header
     }];
 
     this.allRows = [{

--- a/src/app/table/basic-table/example/table-view-example.component.ts
+++ b/src/app/table/basic-table/example/table-view-example.component.ts
@@ -91,25 +91,29 @@ export class TableViewExampleComponent implements OnInit {
       draggable: true,
       prop: 'name',
       name: 'Name',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.addressTemplate,
       draggable: true,
       prop: 'address',
       name: 'Address',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.birthMonthTemplate,
       draggable: true,
       prop: 'birthMonth',
       name: 'Birth Month',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }, {
       cellTemplate: this.weekDayTemplate,
       draggable: true,
       prop: 'weekDay',
       name: 'Week Day',
-      resizeable: true
+      resizeable: true,
+      sortable: false // using sort menu
     }];
 
     this.allRows = [{
@@ -508,7 +512,7 @@ export class TableViewExampleComponent implements OnInit {
     this.currentSortField = $event.field;
     this.isAscendingSort = $event.isAscending;
     this.allRows.sort((item1: any, item2: any) => this.compare(item1, item2));
-    this.updateRows();
+    this.applyFilters(this.filterConfig.appliedFilters || []);
   }
 
   // View

--- a/src/app/table/basic-table/table.component.html
+++ b/src/app/table/basic-table/table.component.html
@@ -52,6 +52,7 @@
                    (reorder)="handleReorder($event)"
                    (resize)="handleResize($event)"
                    (scroll)="handleScroll($event)"
+                   (sort)="handleSort($event)"
                    (tableContextmenu)="handleOnTableContextMenu($event)"
                    *ngIf="showTable">
       <!-- Selection template -->

--- a/src/app/table/basic-table/table.component.ts
+++ b/src/app/table/basic-table/table.component.ts
@@ -14,8 +14,9 @@ import { DragulaService } from 'ng2-dragula';
 
 import { DatatableComponent } from '@swimlane/ngx-datatable';
 
-import { TableConfig } from './table-config';
 import { NgxDataTableConfig } from './ngx-datatable-config';
+import { SortEvent } from '../../sort/sort-event';
+import { TableConfig } from './table-config';
 import { TableBase } from '../table-base';
 import { TableEvent } from '../table-event';
 
@@ -109,6 +110,11 @@ export class TableComponent extends TableBase implements AfterViewInit, DoCheck,
   @Output('onScroll') onScroll = new EventEmitter();
 
   /**
+   * The ngx-datatable event emitted when a column header is sorted
+   */
+  @Output('onSort') onSort = new EventEmitter();
+
+  /**
    * The ngx-datatable event emitted when a context menu is invoked on the table
    */
   // @Output('onTableContextMenu') onTableContextMenu = new EventEmitter();
@@ -156,7 +162,7 @@ export class TableComponent extends TableBase implements AfterViewInit, DoCheck,
       pagerNext: 'datatable-icon-skip'
     },
     externalPaging: false,
-    externalSorting: true,
+    externalSorting: false,
     headerHeight: 50,
     messages: { emptyMessage: 'No records found' },
     offset: 0,
@@ -164,7 +170,9 @@ export class TableComponent extends TableBase implements AfterViewInit, DoCheck,
     rowHeight: 'auto',
     rowIdentity: ((x: any) => x),
     scrollbarH: false,
-    scrollbarV: false
+    scrollbarV: false,
+    sorts: [],
+    sortType: 'multi'
   } as NgxDataTableConfig;
 
   private dragulaName = 'newBag';
@@ -295,9 +303,6 @@ export class TableComponent extends TableBase implements AfterViewInit, DoCheck,
     }
 
     this.columns.forEach((col) => {
-      if (col.sortable === undefined) {
-        col.sortable = false;
-      }
       this._cols.push(col);
     });
   }
@@ -462,6 +467,13 @@ export class TableComponent extends TableBase implements AfterViewInit, DoCheck,
    */
   private handleScroll($event: any): void {
     this.onScroll.emit($event);
+  }
+
+  /**
+   * Helper to generate ngx-datatable sort event
+   */
+  private handleSort($event: any): void {
+    this.onSort.emit($event);
   }
 
   /**


### PR DESCRIPTION
The underlying sort event can be used to apply a paginated sort when the column header is selected.

https://rawgit.com/dlabrecq/patternfly-ng/table-sort-dist/dist-demo/#/table