### PR TITLE
Clean up

### DIFF
--- a/src/app/navigation/application-launcher/application-launcher.component.html
+++ b/src/app/navigation/application-launcher/application-launcher.component.html
@@ -1,21 +1,32 @@
 <div>
-  <div class="applauncher-pf dropdown dropdown-kebab-pf" [ngClass]="{'applauncher-pf-block-list': !showAsList, 'open':opened}"
-       uib-dropdown
-       uib-keyboard-nav="true">
-    <a id="domain-switcher" class="dropdown-toggle drawer-pf-trigger-icon" uib-dropdown-toggle  (click)="toggle()" [ngClass]="{'disabled': disabled}">
+  <div class="applauncher-pf dropdown dropdown-kebab-pf" dropdown
+       [ngClass]="{'applauncher-pf-block-list': !showAsList}">
+    <a class="dropdown-toggle drawer-pf-trigger-icon" href="javascript:void(0)" dropdownToggle
+       *ngIf="!disabled">
       <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
       <span class="applauncher-pf-title">
-              {{label || 'Application Launcher'}}
+        {{label || 'Application Launcher'}}
         <span class="caret" aria-hidden="true"></span>
       </span>
     </a>
-    <ul class="dropdown-menu dropdown-menu-right"
-        uib-dropdown-menu
-        role="menu"
-        aria-labelledby="domain-switcher">
-      <li class="applauncher-pf-item" role="menuitem" *ngFor="let item of items">
-        <a class="applauncher-pf-link" href="{{item.url}}" target="{{item.target || '_blank'}}"  *ngFor="let badge of item.badges" title="{{badge.tooltip}}">
-          <i class="applauncher-pf-link-icon pficon" class="{{item.iconStyleClass}}" *ngIf="item.iconStyleClass" [ngClass]="{hidden: hiddenIcons}" aria-hidden="true"></i>
+    <a class="dropdown-toggle drawer-pf-trigger-icon disabled" href="javascript:void(0)"
+       onclick="return false;"
+       *ngIf="disabled">
+      <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+      <span class="applauncher-pf-title">
+        {{label || 'Application Launcher'}}
+        <span class="caret" aria-hidden="true"></span>
+      </span>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-right" role="menu" *dropdownMenu>
+      <li class="applauncher-pf-item" *ngFor="let item of items">
+        <a class="applauncher-pf-link" href="{{item.url}}"
+           target="{{item.target || '_blank'}}"
+           title="{{badge.tooltip}}" role="menuitem"
+           *ngFor="let badge of item.badges">
+          <i class="applauncher-pf-link-icon pficon {{item.iconStyleClass}}" aria-hidden="true"
+             [ngClass]="{hidden: !showIcons}"
+             *ngIf="item.iconStyleClass"></i>
           <span class="applauncher-pf-link-title">{{item.title}}</span>
         </a>
       </li>

--- a/src/app/navigation/application-launcher/application-launcher.component.spec.ts
+++ b/src/app/navigation/application-launcher/application-launcher.component.spec.ts
@@ -1,123 +1,112 @@
 import {
-    async,
-    ComponentFixture,
-    TestBed
-  } from '@angular/core/testing';
-  import { By } from '@angular/platform-browser';
-  import { FormsModule } from '@angular/forms';
-  import { RouterTestingModule } from '@angular/router/testing';
-  import { NavigationItemConfig } from '../navigation-item-config';
-  import { TooltipModule } from 'ngx-bootstrap';
-  import { ApplicationLauncherComponent } from './application-launcher.component';
+  async,
+  fakeAsync,
+  tick,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap';
 
-  describe('Application Launcher componet', () => {
-    let comp: ApplicationLauncherComponent;
-    let fixture: ComponentFixture<ApplicationLauncherComponent>;
-    let navigationItems: NavigationItemConfig[];
-    let isClicked: boolean = false;
+import { ApplicationLauncherComponent } from './application-launcher.component';
+import { NavigationItemConfig } from '../navigation-item-config';
 
+describe('Application Launcher componet', () => {
+  let comp: ApplicationLauncherComponent;
+  let fixture: ComponentFixture<ApplicationLauncherComponent>;
+  let navigationItems: NavigationItemConfig[];
 
-    beforeEach(() => {
-
-      navigationItems = [
-        {
-          title: 'Recteque',
-          url : '#/applauncher/recteque',
-          iconStyleClass: 'pficon-storage-domain',
-          badges: [{
-                    count: 1,
-                    tooltip: 'Launch the Function User Interface'
-
-          }]
-        },
-        {
-          title: 'Suavitate',
-          url : '#/applauncher/intellegam/suavitate',
-          iconStyleClass: 'pficon-build',
-          badges: [{
-                  count: 2,
-                  tooltip: 'Launch the Function User Interface'
-          }]
-        },
-        {
-          title: 'Lorem',
-          url : '#/applauncher/intellegam/lorem',
-          iconStyleClass: 'pficon-domain',
-          badges: [{
-                  count: 3,
-                  tooltip: 'Launch the Function User Interface'
-          }]
-        },
-        {
-          title: 'Home',
-          url : '/',
-          iconStyleClass: 'pficon-home',
-          badges: [{
-                  count: 4,
-                  tooltip: 'Launch the Function User Interface'
-          }]
-        }
-      ];
-
-    });
-
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [FormsModule, TooltipModule.forRoot(), RouterTestingModule],
-        declarations: [ApplicationLauncherComponent]
-      })
-        .compileComponents()
-        .then(() => {
-          fixture = TestBed.createComponent(ApplicationLauncherComponent);
-          comp = fixture.componentInstance;
-
-
-          comp.items = navigationItems;
-          comp.label = 'Application Launche';
-          comp.showAsList = false;
-          comp.hiddenIcons = false;
-          comp.disabled = false;
-
-          fixture.detectChanges();
-        });
-    }));
-
-    it('should add the applauncher nav ', () => {
-      let primaryMenu = fixture.debugElement.query(By.css('.applauncher-pf'));
-      expect(primaryMenu).not.toBeNull();
-
-    });
-
-    it('should not show icons in hiddenIcons mode', () => {
-
-      comp.hiddenIcons = true;
-      fixture.detectChanges();
-
-      let primaryItems = fixture.debugElement.queryAll(
-        By.css('.applauncher-pf-item'));
-        expect(primaryItems.length).toBe(4);
-
-
-      let iconSpan = primaryItems[0].query(By.css('.applauncher-pf-item > a > i'));
-      expect(iconSpan.classes['hidden']).toBeTruthy();
-    });
-
-
-    it('should invoke the toggle when an item is clicked', () => {
-      expect(comp.opened).toBeFalsy();
-
-      let primaryItems = fixture.debugElement.query(
-        By.css('.applauncher-pf > a'));
-        expect(primaryItems);
-
-      primaryItems.triggerEventHandler('click', {});
-      fixture.detectChanges();
-
-      expect(comp.opened).toBeTruthy();
-
-    });
-
-
+  beforeEach(() => {
+    navigationItems = [{
+      title: 'Recteque',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-storage-domain',
+      badges: [{
+        count: 1,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Suavitate',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-build',
+      badges: [{
+        count: 2,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Lorem',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-domain',
+      badges: [{
+        count: 3,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Home',
+      url : '/',
+      iconStyleClass: 'pficon-home',
+      badges: [{
+        count: 4,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }];
   });
 
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BsDropdownModule.forRoot(),
+        FormsModule,
+        TooltipModule.forRoot()
+      ],
+      declarations: [ApplicationLauncherComponent],
+      providers: [BsDropdownConfig]
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(ApplicationLauncherComponent);
+        comp = fixture.componentInstance;
+        comp.items = navigationItems;
+        comp.label = 'Application Launcher';
+        comp.showAsList = false;
+        comp.showIcons = true;
+        comp.disabled = false;
+        fixture.detectChanges();
+      });
+  }));
+
+  it('should add the applauncher nav ', () => {
+    let primaryMenu = fixture.debugElement.query(By.css('.applauncher-pf'));
+    expect(primaryMenu).not.toBeNull();
+  });
+
+  it('should not show icons', fakeAsync(() => {
+    comp.showIcons = false;
+    const element = fixture.nativeElement;
+
+    let button = element.querySelector('.applauncher-pf .dropdown-toggle');
+    button.click();
+    tick();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+
+    let primaryItems = fixture.debugElement.queryAll(By.css('.applauncher-pf-item'));
+    expect(primaryItems.length).toBe(4);
+
+    let iconSpan = primaryItems[0].query(By.css('.applauncher-pf-item > a > i'));
+    expect(iconSpan.classes['hidden']).toBeTruthy();
+  }));
+
+  it('should invoke the toggle when an item is clicked', () => {
+    let menu = fixture.debugElement.query(By.css('.applauncher-pf'));
+    expect(menu);
+
+    menu.triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    menu = fixture.debugElement.query(By.css('.applauncher-pf .open'));
+    expect(menu);
+  });
+});

--- a/src/app/navigation/application-launcher/application-launcher.component.ts
+++ b/src/app/navigation/application-launcher/application-launcher.component.ts
@@ -1,89 +1,55 @@
 import {
-    Component, ElementRef, EventEmitter,
-    Input, OnInit, Output, Renderer2,
-    TemplateRef, ViewEncapsulation
+  Component,
+  Input,
+  OnInit,
+  ViewEncapsulation
 } from '@angular/core';
 
 import { NavigationItemConfig } from '../navigation-item-config';
-import { read } from 'fs-extra';
 
 @Component({
-    encapsulation: ViewEncapsulation.None,
-    selector: 'pfng-application-launcher',
-    templateUrl: './application-launcher.component.html'
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-application-launcher',
+  templateUrl: './application-launcher.component.html'
 })
 
 /**
  * Application launcher component
  */
 export class ApplicationLauncherComponent  implements OnInit {
+  /**
+   * Disable the application launcher button, default: false
+   */
+  @Input() disabled: boolean;
 
-    /**
-     *  Use a custom label for the launcher, default: Application Launcher
-     */
-    @Input() label: string;
+  /**
+   * The navigation items used to build the menu
+   */
+  @Input() items: NavigationItemConfig[];
 
+  /**
+   *  Use a custom label for the launcher, default: Application Launcher
+   */
+  @Input() label: string;
 
-    /**
-     * Disable the application launcher button, default: false
-     */
-    @Input() disabled: boolean;
+  /**
+   * Display items as a list instead of a grid, default: false
+   */
+  @Input() showAsList: boolean = false;
 
+  /**
+   * Flag to show icons on the launcher, default: true
+   */
+  @Input() showIcons: boolean = true;
 
-    /**
-     * Display items as a list instead of a grid, default: false
-     */
-    @Input() showAsList: boolean;
+  /**
+   * The default constructor
+   */
+  constructor() {}
 
-
-    /**
-     * Flag to not show icons on the launcher, default: false
-     */
-    @Input() hiddenIcons: boolean;
-
-
-    /**
-     * The navigation items used to build the menu
-     */
-    @Input() items: NavigationItemConfig[];
-
-
-    /**
-     * Internal boolean to toggle launcher, default:false
-     */
-    private _opened: boolean;
-
-
-    /**
-     * The default constructor
-     */
-    constructor() {}
-
-    /**
-     * Initialize variable
-     */
-    ngOnInit(): void {
-      this._opened = false;
-    }
-
-    /**
-     * getter
-     */
-    get opened(): boolean {
-      return this._opened;
-      }
-
-    /**
-     * toggle function for launcher, active when click, return false on isDisabled:true
-     */
-   public toggle() {
-      if (this.disabled) {
-        return false;
-      } else {
-        this._opened = !this._opened;
-      }
-
-    }
-
-
+  /**
+   * Initialize variable
+   */
+  ngOnInit(): void {
+  }
 }

--- a/src/app/navigation/application-launcher/example/application-launcher-example.component.html
+++ b/src/app/navigation/application-launcher/example/application-launcher-example.component.html
@@ -4,7 +4,6 @@
       <h4>Application Launcher</h4>
       <hr/>
     </div>
-
     <div class="col-sm-8">
       <nav class="navbar navbar-default navbar-pf" role="navigation">
         <div class="navbar-header">
@@ -14,12 +13,21 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand active" id="logo" routerlink="/" routerlinkactive="active" title="" ng-reflect-router-link="/" ng-reflect-router-link-active="active" href="#/">PatternFly NG</a>
+          <a class="navbar-brand active" href="#/" id="logo" title=""
+             routerlink="/"
+             routerlinkactive="active"
+             ng-reflect-router-link="/"
+             ng-reflect-router-link-active="active">PatternFly NG</a>
         </div>
         <nav class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
             <li class="dropdown" style="padding: 5px">
-              <pfng-application-launcher [label]="'Application Launcher'" [disabled]="false" [showAsList]="false" [items]="navigationItems" [hiddenIcons]="hideIcons">
+              <pfng-application-launcher
+                  [disabled]="disabled"
+                  [items]="navigationItems"
+                  [label]="'Application Launcher'"
+                  [showAsList]="false"
+                  [showIcons]="showIcons">
               </pfng-application-launcher>
             </li>
           </ul>
@@ -27,25 +35,29 @@
       </nav>
     </div>
   </div>
-
   <div class="row padding-top-10">
     <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
       <form role="form">
         <div class="form-group">
-          <label></label>
-          <br />
-          <label class="radio-inline">
-            <input type="radio" name="icons" class="form-check-input" [(ngModel)]="hideIcons" value="false">Icons
+          <label class="checkbox-inline">
+            <input id="disabled" name="disabled" type="checkbox"
+                   [(ngModel)]="disabled">Disabled
           </label>
-          <label class="radio-inline">
-            <input type="radio" name="icons" class="form-check-input" [(ngModel)]="hideIcons" value="true" >No Icons
+          <label class="checkbox-inline">
+            <input id="showIcons" name="showIcons" type="checkbox"
+                   [(ngModel)]="showIcons">Icons
           </label>
         </div>
       </form>
     </div>
   </div>
-
-  <div class="row padding-bottom-15 padding-top-15">
+  <div class="row padding-top-10">
     <div class="col-sm-12">
       <h4>Code</h4>
       <hr/>

--- a/src/app/navigation/application-launcher/example/application-launcher-example.component.ts
+++ b/src/app/navigation/application-launcher/example/application-launcher-example.component.ts
@@ -1,75 +1,59 @@
 import {
-    Component, ElementRef, EventEmitter,
-    Input, OnInit, Output, Renderer2,
-    TemplateRef, ViewEncapsulation
+  Component,
+  OnInit,
+  ViewEncapsulation
 } from '@angular/core';
 
 import { NavigationItemConfig } from '../../navigation-item-config';
 
 @Component({
-    encapsulation: ViewEncapsulation.None,
-    selector: 'application-launcher-example',
-    templateUrl: './application-launcher-example.component.html'
+  encapsulation: ViewEncapsulation.None,
+  selector: 'application-launcher-example',
+  templateUrl: './application-launcher-example.component.html'
 })
-
 export class ApplicationLauncherExampleComponent  implements OnInit {
-
-
-  hideIcons: boolean = false;
-
-
-
+  disabled: boolean = false;
   navigationItems: NavigationItemConfig[];
+  showIcons: boolean = true;
 
   ngOnInit(): void {
-    this.navigationItems = [
-      {
-        title: 'Recteque',
-        url : '#/applauncher/recteque',
-        iconStyleClass: 'pficon-storage-domain',
-        badges: [{
-                  count: 1,
-                  tooltip: 'Launch the Function User Interface'
-
-        }]
-      },
-      {
-        title: 'Suavitate',
-        url : '#/applauncher/intellegam/suavitate',
-        iconStyleClass: 'pficon-build',
-        badges: [{
-                count: 2,
-                tooltip: 'Launch the Function User Interface'
-        }]
-      },
-      {
-        title: 'Lorem',
-        url : '#/applauncher/intellegam/lorem',
-        iconStyleClass: 'pficon-domain',
-        badges: [{
-                count: 3,
-                tooltip: 'Launch the Function User Interface'
-        }]
-      },
-      {
-        title: 'Home',
-        url : '/',
-        iconStyleClass: 'pficon-home',
-        badges: [{
-                count: 4,
-                tooltip: 'Launch the Function User Interface'
-        }]
-      }
-    ];
-
+    this.navigationItems = [{
+      title: 'Recteque',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-storage-domain',
+      badges: [{
+        count: 1,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Suavitate',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-build',
+      badges: [{
+        count: 2,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Lorem',
+      url : '#/applauncher',
+      iconStyleClass: 'pficon-domain',
+      badges: [{
+        count: 3,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }, {
+      title: 'Home',
+      url : '/',
+      iconStyleClass: 'pficon-home',
+      badges: [{
+        count: 4,
+        tooltip: 'Launch the Function User Interface'
+      }]
+    }];
   }
-    /**
-     * The default constructor
-     */
-    constructor() {}
 
-
-
-
+  /**
+   * The default constructor
+   */
+  constructor() {}
 }
-

--- a/src/app/navigation/application-launcher/example/application-launcher-example.module.ts
+++ b/src/app/navigation/application-launcher/example/application-launcher-example.module.ts
@@ -9,8 +9,6 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
 import { ApplicationLauncherExampleComponent } from './application-launcher-example.component';
 import { RouterModule } from '@angular/router';
 
-
-
 @NgModule({
   imports: [
     CommonModule,

--- a/src/app/navigation/navigation.module.ts
+++ b/src/app/navigation/navigation.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { NavigationItemConfig } from './navigation-item-config';
@@ -16,9 +17,13 @@ export {
  * A module containing objects associated with the navigation components
  */
 @NgModule({
-  imports: [CommonModule, TooltipModule.forRoot()],
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    TooltipModule.forRoot()
+  ],
   declarations: [ ApplicationLauncherComponent, VerticalNavigationComponent],
   exports: [ ApplicationLauncherComponent, VerticalNavigationComponent],
-  providers: [TooltipConfig, WindowReference]
+  providers: [BsDropdownConfig, TooltipConfig, WindowReference]
 })
 export class NavigationModule {}

--- a/src/demo/navbar/navbar-items.ts
+++ b/src/demo/navbar/navbar-items.ts
@@ -67,13 +67,13 @@ export class NavbarItems {
     id: 'navigation',
     title: 'Navigation',
     children: [{
-      id: 'verticalnavigation',
-      path: 'verticalnavigation',
-      title: 'Vertical Navigation',
-    }, {
       id: 'applauncher',
       path: 'applauncher',
-      title: 'Application Launcher',
+      title: 'Application Launcher'
+    }, {
+      id: 'verticalnavigation',
+      path: 'verticalnavigation',
+      title: 'Vertical Navigation'
     }]
    }, {
     id: 'notifications',


### PR DESCRIPTION
This cleans up some formatting, removes unused classes, fixes duplicate class attributes, and removes uib-dropdown and uib-keyboard-nav attributes leftover from angular-bootstrap — using ngx-bootstrap dropdown instead. Also adding the 'feat' commit comment here as it was missing -- a new feature release was never created.