### PR TITLE
tree-list: expansion toggle should show a pointer cursor

### DIFF
--- a/src/app/list/tree-list/tree-list.component.less
+++ b/src/app/list/tree-list/tree-list.component.less
@@ -54,6 +54,7 @@
 
   // Padding for toggle down
   .toggle-children-wrapper {
+    cursor: pointer;
     padding: 0;
     &.toggle-children-wrapper-expanded {
       padding-right: 5px;


### PR DESCRIPTION
Fixes: https://github.com/patternfly/patternfly-ng/issues/325
