### PR TITLE
Table: Ensure table can be loaded from an empty state

### DIFF
--- a/src/app/table/basic-table/example/table-empty-example.component.html
+++ b/src/app/table/basic-table/example/table-empty-example.component.html
@@ -1,0 +1,147 @@
+<div class="padding-15">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="form-group">
+        <p>This demos ensures a table can be loaded from an initial empty state</p>
+        <pfng-table
+            [actionTemplate]="actionTemplate"
+            [columns]="columns"
+            [config]="tableConfig"
+            [expandRowTemplate]="expandRowTemplate"
+            [rows]="rows"
+            (onActivate)="handleOnActivate($event)"
+            (onActionSelect)="handleAction($event)"
+            (onFilterChange)="filterChanged($event)"
+            (onFilterFieldSelect)="filterFieldSelected($event)"
+            (onFilterTypeAhead)="filterQueries($event)"
+            (onPageNumberChange)="handlePageNumber($event)"
+            (onPageSizeChange)="handlePageSize($event)"
+            (onReorder)="handleOnReorder($event)"
+            (onResize)="handleOnResize($event)"
+            (onScroll)="handleOnScroll($event)"
+            (onSelectionChange)="handleSelectionChange($event)"
+            (onSortChange)="handleSortChanged($event)">
+        </pfng-table>
+        <!-- Column templates -->
+        <ng-template #nameTemplate let-row="row">
+          <span>{{row.name}}</span>
+        </ng-template>
+        <ng-template #addressTemplate let-row="row">
+          <span>{{row.address}}</span>
+        </ng-template>
+        <ng-template #birthMonthTemplate let-row="row">
+          <span>{{row.birthMonth}}</span>
+        </ng-template>
+        <ng-template #weekDayTemplate let-row="row">
+          <span>{{row.weekDay}}</span>
+        </ng-template>
+        <!-- Toolbar action template -->
+        <ng-template #actionTemplate>
+            <span class="dropdown primary-action" dropdown>
+              <button class="btn btn-default dropdown-toggle" type="button" dropdownToggle>
+                Menu Action<span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu" *dropdownMenu>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" (click)="optionSelected(1)">Option 1</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(2)">Option 2</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(3)">Option 3</a>
+                </li>
+                <li role="menuitem">
+                  <a class="dropdown-item secondary-action" role="menuitem" (click)="optionSelected(4)">Option 4</a>
+                </li>
+              </ul>
+            </span>
+          <button class="btn btn-default primary-action" type="button" (click)="doAdd()">
+            <span class="fa fa-plus"></span>
+            Add Action
+          </button>
+        </ng-template>
+        <!-- Row detail template -->
+        <ng-template #expandRowTemplate let-row="row">
+          <div class="margin-left-20">
+            <div><strong>Address</strong></div>
+            <div>{{row.address}}</div>
+          </div>
+        </ng-template>
+      </div>
+    </div>
+  </div>
+  <div class="row padding-top-10">
+    <div class="col-sm-12">
+      <h4 class="actions-label">Settings</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="cb" name="cb" type="checkbox"
+                   [(ngModel)]="tableConfig.showCheckbox">Checkbox
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="useExpandingRows" name="useExpandingRows" type="checkbox"
+                   [(ngModel)]="tableConfig.useExpandRows">Simple Expansion
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <form role="form">
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input id="itemsAvailable" name="itemsAvailable" type="checkbox"
+                   [(ngModel)]="rowsAvailable"
+                   (ngModelChange)="updateItemsAvailable()">Rows Available
+          </label>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row padding-top-10">
+    <div class="col-sm-12">
+      <h4 class="actions-label">Actions</h4>
+      <hr/>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <textarea rows="3" class="col-sm-12">{{actionsText}}</textarea>
+    </div>
+  </div>
+  <div class="row padding-top-10">
+    <div class="col-sm-12">
+      <h4>Code</h4>
+      <hr/>
+    </div>
+  </div>
+  <div>
+    <tabset>
+      <tab heading="api">
+        <iframe class="demoframe" src="docs/classes/tablecomponent.html"></iframe>
+      </tab>
+      <tab heading="html">
+        <include-content src="src/app/table/basic-table/example/table-empty-example.component.html"></include-content>
+      </tab>
+      <tab heading="typescript">
+        <include-content src="src/app/table/basic-table/example/table-empty-example.component.ts"></include-content>
+      </tab>
+    </tabset>
+  </div>
+</div>

--- a/src/app/table/basic-table/example/table-empty-example.component.ts
+++ b/src/app/table/basic-table/example/table-empty-example.component.ts
@@ -1,0 +1,565 @@
+import {
+  AfterViewInit,
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { Action } from '../../../action/action';
+import { ActionConfig } from '../../../action/action-config';
+import { EmptyStateConfig } from '../../../empty-state/empty-state-config';
+import { Filter } from '../../../filter/filter';
+import { FilterConfig } from '../../../filter/filter-config';
+import { FilterField } from '../../../filter/filter-field';
+import { FilterEvent } from '../../../filter/filter-event';
+import { FilterType } from '../../../filter/filter-type';
+import { PaginationConfig } from '../../../pagination/pagination-config';
+import { PaginationEvent } from '../../../pagination/pagination-event';
+import { SortConfig } from '../../../sort/sort-config';
+import { SortField } from '../../../sort/sort-field';
+import { SortEvent } from '../../../sort/sort-event';
+import { TableConfig } from '../table-config';
+import { TableEvent } from '../../table-event';
+import { ToolbarConfig } from '../../../toolbar/toolbar-config';
+
+import { cloneDeep } from 'lodash';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'table-empty-example',
+  templateUrl: './table-empty-example.component.html'
+})
+export class TableEmptyExampleComponent implements AfterViewInit, OnInit {
+  @ViewChild('addressTemplate') addressTemplate: TemplateRef<any>;
+  @ViewChild('birthMonthTemplate') birthMonthTemplate: TemplateRef<any>;
+  @ViewChild('nameTemplate') nameTemplate: TemplateRef<any>;
+  @ViewChild('weekDayTemplate') weekDayTemplate: TemplateRef<any>;
+
+  actionConfig: ActionConfig;
+  actionsText: string = '';
+  allRows: any[];
+  columns: any[];
+  currentSortField: SortField;
+  tableConfig: TableConfig;
+  emptyStateConfig: EmptyStateConfig;
+  filterConfig: FilterConfig;
+  filteredRows: any[];
+  filtersText: string = '';
+  isAscendingSort: boolean = true;
+  paginationConfig: PaginationConfig;
+  rows: any[];
+  rowsAvailable: boolean = false;
+  separator: Object;
+  sortConfig: SortConfig;
+  toolbarConfig: ToolbarConfig;
+  weekDayQueries: any[];
+
+  monthVals: any = {
+    'January': 1,
+    'February': 2,
+    'March': 3,
+    'April': 4,
+    'May': 5,
+    'June': 6,
+    'July': 7,
+    'August': 8,
+    'September': 9,
+    'October': 10,
+    'November': 11,
+    'December': 12
+  };
+
+  weekDayVals: any = {
+    'Sunday': 1,
+    'Monday': 2,
+    'Tuesday': 3,
+    'Wednesday': 4,
+    'Thursday': 5,
+    'Friday': 6,
+    'Saturday': 7
+  };
+
+  constructor() {
+  }
+
+  ngAfterViewInit(): void {
+    // this.updateRows(false); // Reinitialize expanded rows in order to render properly with tabs
+  }
+
+  ngOnInit(): void {
+    this.columns = [{
+      cellTemplate: this.nameTemplate,
+      draggable: true,
+      prop: 'name',
+      name: 'Name',
+      resizeable: true,
+      sortable: false // using sort menu
+    }, {
+      cellTemplate: this.addressTemplate,
+      draggable: true,
+      prop: 'address',
+      name: 'Address',
+      resizeable: true,
+      sortable: false // using sort menu
+    }, {
+      cellTemplate: this.birthMonthTemplate,
+      draggable: true,
+      prop: 'birthMonth',
+      name: 'Birth Month',
+      resizeable: true,
+      sortable: false // using sort menu
+    }, {
+      cellTemplate: this.weekDayTemplate,
+      draggable: true,
+      prop: 'weekDay',
+      name: 'Week Day',
+      resizeable: true,
+      sortable: false // using sort menu
+    }];
+
+    this.allRows = [{
+      name: 'Fred Flintstone',
+      address: '20 Dinosaur Way, Bedrock, Washingstone',
+      birthMonth: 'February',
+      birthMonthId: 'month2',
+      weekDay: 'Sunday',
+      weekdayId: 'day1'
+    }, {
+      name: 'John Smith',
+      address: '415 East Main Street, Norfolk, Virginia',
+      birthMonth: 'October',
+      birthMonthId: '10',
+      // selected: true,
+      weekDay: 'Monday',
+      weekdayId: 'day2'
+    }, {
+      name: 'Frank Livingston',
+      address: '234 Elm Street, Pittsburgh, Pennsylvania',
+      birthMonth: 'March',
+      birthMonthId: 'month3',
+      weekDay: 'Tuesday',
+      weekdayId: 'day3'
+    }, {
+      name: 'Judy Green',
+      address: '2 Apple Boulevard, Cincinatti, Ohio',
+      birthMonth: 'December',
+      birthMonthId: 'month12',
+      weekDay: 'Wednesday',
+      weekdayId: 'day4'
+    }, {
+      name: 'Pat Thomas',
+      address: '50 Second Street, New York, New York',
+      birthMonth: 'February',
+      birthMonthId: 'month2',
+      weekDay: 'Thursday',
+      weekdayId: 'day5'
+    }];
+    this.filteredRows = this.allRows;
+
+    this.paginationConfig = {
+      pageNumber: 1,
+      pageSize: 3,
+      pageSizeIncrements: [2, 3, 4],
+      totalItems: this.filteredRows.length
+    } as PaginationConfig;
+
+    // Need to initialize for results/total counts
+    // this.updateRows(false);
+
+    this.weekDayQueries = [{
+      id: 'day1',
+      value: 'Sunday'
+    }, {
+      id: 'day2',
+      value: 'Monday'
+    }, {
+      id: 'day3',
+      value: 'Tuesday'
+    }, {
+      id: 'day4',
+      value: 'Wednesday'
+    }, {
+      id: 'day5',
+      value: 'Thursday'
+    }, {
+      id: 'day6',
+      value: 'Friday'
+    }, {
+      id: 'day7',
+      value: 'Saturday'
+    }];
+
+    this.filterConfig = {
+      fields: [{
+        id: 'name',
+        title: 'Name',
+        placeholder: 'Filter by Name...',
+        type: FilterType.TEXT
+      }, {
+        id: 'address',
+        title: 'Address',
+        placeholder: 'Filter by Address...',
+        type: FilterType.TEXT
+      }, {
+        id: 'birthMonth',
+        title: 'Birth Month',
+        placeholder: 'Filter by Birth Month...',
+        type: FilterType.SELECT,
+        queries: [{
+          id: 'month1',
+          value: 'January'
+        }, {
+          id: 'month2',
+          value: 'February'
+        }, {
+          id: 'month3',
+          value: 'March'
+        }, {
+          id: 'month4',
+          value: 'April'
+        }, {
+          id: 'month5',
+          value: 'May'
+        }, {
+          id: 'month6',
+          value: 'June'
+        }, {
+          id: 'month7',
+          value: 'July'
+        }, {
+          id: 'month8',
+          value: 'August'
+        }, {
+          id: 'month9',
+          value: 'September'
+        }, {
+          id: 'month10',
+          value: 'October'
+        }, {
+          id: 'month11',
+          value: 'November'
+        }, {
+          id: 'month12',
+          value: 'December'
+        }]
+      }, {
+        id: 'weekDay',
+        title: 'Week Day',
+        placeholder: 'Filter by Week Day...',
+        type: FilterType.TYPEAHEAD,
+        queries: [
+          ...this.weekDayQueries
+        ]
+      }] as FilterField[],
+      appliedFilters: [],
+      resultsCount: 0, // this.rows.length,
+      totalCount: 0, // this.allRows.length
+    } as FilterConfig;
+
+    this.sortConfig = {
+      fields: [{
+        id: 'name',
+        title: 'Name',
+        sortType: 'alpha'
+      }, {
+        id: 'address',
+        title: 'Address',
+        sortType: 'alpha'
+      }, {
+        id: 'birthMonth',
+        title: 'Birth Month',
+        sortType: 'alpha'
+      }, {
+        id: 'weekDay',
+        title: 'Week Day',
+        sortType: 'alpha'
+      }],
+      isAscending: this.isAscendingSort
+    } as SortConfig;
+
+    this.actionConfig = {
+      primaryActions: [{
+        id: 'action1',
+        title: 'Action 1',
+        tooltip: 'Do the first thing'
+      }, {
+        id: 'action2',
+        title: 'Action 2',
+        tooltip: 'Do something else'
+      }],
+      moreActions: [{
+        id: 'moreActions1',
+        title: 'Action',
+        tooltip: 'Perform an action'
+      }, {
+        id: 'moreActions2',
+        title: 'Another Action',
+        tooltip: 'Do something else'
+      }, {
+        disabled: true,
+        id: 'moreActions3',
+        title: 'Disabled Action',
+        tooltip: 'Unavailable action',
+      }, {
+        id: 'moreActions4',
+        title: 'Something Else',
+        tooltip: 'Do something special'
+      }, {
+        id: 'moreActions5',
+        title: '',
+        separator: true
+      }, {
+        id: 'moreActions6',
+        title: 'Grouped Action 1',
+        tooltip: 'Do something'
+      }, {
+        id: 'moreActions7',
+        title: 'Grouped Action 2',
+        tooltip: 'Do something similar'
+      }]
+    } as ActionConfig;
+
+    this.emptyStateConfig = {
+      actions: {
+        primaryActions: [{
+          id: 'action1',
+          title: 'Main Action',
+          tooltip: 'Start the server'
+        }],
+        moreActions: [{
+          id: 'action2',
+          title: 'Secondary Action 1',
+          tooltip: 'Do the first thing'
+        }, {
+          id: 'action3',
+          title: 'Secondary Action 2',
+          tooltip: 'Do something else'
+        }, {
+          id: 'action4',
+          title: 'Secondary Action 3',
+          tooltip: 'Do something special'
+        }]
+      } as ActionConfig,
+      iconStyleClass: 'pficon-warning-triangle-o',
+      title: 'No Items Available',
+      info: 'This is the Empty State component. The goal of a empty state pattern is to provide a good first ' +
+      'impression that helps users to achieve their goals. It should be used when a list is empty because no ' +
+      'objects exists and you want to guide the user to perform specific actions.',
+      helpLink: {
+        hypertext: 'Table example',
+        text: 'For more information please see the',
+        url: '#/table'
+      }
+    } as EmptyStateConfig;
+
+    this.toolbarConfig = {
+      actionConfig: this.actionConfig,
+      filterConfig: this.filterConfig,
+      sortConfig: this.sortConfig
+    } as ToolbarConfig;
+
+    this.tableConfig = {
+      emptyStateConfig: this.emptyStateConfig,
+      paginationConfig: this.paginationConfig,
+      showCheckbox: true,
+      toolbarConfig: this.toolbarConfig,
+      useExpandRows: true
+    } as TableConfig;
+  }
+
+  // Actions
+
+  doAdd(): void {
+    this.actionsText = 'Add Action\n' + this.actionsText;
+  }
+
+  handleAction(action: Action): void {
+    this.actionsText = action.title + '\n' + this.actionsText;
+  }
+
+  optionSelected(option: number): void {
+    this.actionsText = 'Option ' + option + ' selected\n' + this.actionsText;
+  }
+
+  // Filter
+
+  applyFilters(filters: Filter[]): void {
+    this.filteredRows = [];
+    if (filters && filters.length > 0) {
+      this.allRows.forEach((item) => {
+        if (this.matchesFilters(item, filters)) {
+          this.filteredRows.push(item);
+        }
+      });
+    } else {
+      this.filteredRows = this.allRows;
+    }
+    this.toolbarConfig.filterConfig.resultsCount = this.filteredRows.length;
+    this.updateRows(true);
+  }
+
+  // Handle filter changes
+  filterChanged($event: FilterEvent): void {
+    this.filtersText = '';
+    $event.appliedFilters.forEach((filter) => {
+      this.filtersText += filter.field.title + ' : ' + filter.value + '\n';
+    });
+    this.applyFilters($event.appliedFilters);
+    this.filterFieldSelected($event);
+  }
+
+  // Reset filtered queries
+  filterFieldSelected($event: FilterEvent): void {
+    this.filterConfig.fields.forEach((field) => {
+      if (field.id === 'weekDay') {
+        field.queries = [
+          ...this.weekDayQueries
+        ];
+      }
+    });
+  }
+
+  matchesFilter(item: any, filter: Filter): boolean {
+    let match = true;
+    if (filter.field.id === 'name') {
+      match = item.name.match(filter.value) !== null;
+    } else if (filter.field.id === 'address') {
+      match = item.address.match(filter.value) !== null;
+    } else if (filter.field.id === 'birthMonth') {
+      match = item.birthMonth === filter.value;
+    } else if (filter.field.id === 'weekDay') {
+      match = item.weekDay === filter.value;
+    }
+    return match;
+  }
+
+  matchesFilters(item: any, filters: Filter[]): boolean {
+    let matches = true;
+    filters.forEach((filter) => {
+      if (!this.matchesFilter(item, filter)) {
+        matches = false;
+        return matches;
+      }
+    });
+    return matches;
+  }
+
+  // Filter queries for type ahead
+  filterQueries($event: FilterEvent) {
+    const index = (this.filterConfig.fields as any).findIndex((i: any) => i.id === $event.field.id);
+    let val = $event.value.trim();
+
+    if (this.filterConfig.fields[index].id === 'weekDay') {
+      this.filterConfig.fields[index].queries = [
+        ...this.weekDayQueries.filter((item: any) => {
+          if (item.value) {
+            return (item.value.toLowerCase().indexOf(val.toLowerCase()) > -1);
+          } else {
+            return true;
+          }
+        })
+      ];
+    }
+  }
+
+  // Drag and drop
+
+  handleDrop($event: any[]): void {
+    // Save new row order
+    let startIndex = (this.paginationConfig.pageNumber - 1) * this.paginationConfig.pageSize;
+    let endIndex = startIndex + this.paginationConfig.pageSize;
+    for (let i = startIndex; i < endIndex; i++) {
+      this.allRows[i] = $event[i];
+    }
+    this.actionsText = 'Row dropped' + '\n' + this.actionsText;
+  }
+
+  // ngx-datatable
+
+  handleOnActivate($event: any): void {
+    // To much noise
+    // this.actionsText = 'Cell or row focused' + '\n' + this.actionsText;
+  }
+
+  handleOnReorder($event: any): void {
+    this.actionsText = 'Columns reordered' + '\n' + this.actionsText;
+  }
+
+  handleOnResize($event: any): void {
+    this.actionsText = 'Columns resized' + '\n' + this.actionsText;
+  }
+
+  handleOnScroll($event: any): void {
+    this.actionsText = 'Body scrolled' + '\n' + this.actionsText;
+  }
+
+  // Pagination
+
+  handlePageSize($event: PaginationEvent): void {
+    this.actionsText = 'Page Size: ' + $event.pageSize + ' Selected' + '\n' + this.actionsText;
+    this.updateRows(false);
+  }
+
+  handlePageNumber($event: PaginationEvent): void {
+    this.actionsText = 'Page Number: ' + $event.pageNumber + ' Selected' + '\n' + this.actionsText;
+    this.updateRows(false);
+  }
+
+  updateRows(reset: boolean): void {
+    if (reset) {
+      this.paginationConfig.pageNumber = 1;
+    }
+    this.paginationConfig.totalItems = this.filteredRows.length;
+    this.rows = this.filteredRows.slice((this.paginationConfig.pageNumber - 1) * this.paginationConfig.pageSize,
+      this.paginationConfig.totalItems).slice(0, this.paginationConfig.pageSize);
+  }
+
+  // Sort
+
+  compare(item1: any, item2: any): number {
+    let compValue = 0;
+    if (this.currentSortField.id === 'name') {
+      compValue = item1.name.localeCompare(item2.name);
+    } else if (this.currentSortField.id === 'address') {
+      compValue = item1.address.localeCompare(item2.address);
+    } else if (this.currentSortField.id === 'birthMonth') {
+      compValue = this.monthVals[item1.birthMonth] - this.monthVals[item2.birthMonth];
+    } else if (this.currentSortField.id === 'weekDay') {
+      compValue = this.weekDayVals[item1.weekDay] - this.weekDayVals[item2.weekDay];
+    }
+
+    if (!this.isAscendingSort) {
+      compValue = compValue * -1;
+    }
+    return compValue;
+  }
+
+  // Handle sort changes
+  handleSortChanged($event: SortEvent): void {
+    this.currentSortField = $event.field;
+    this.isAscendingSort = $event.isAscending;
+    this.allRows.sort((item1: any, item2: any) => this.compare(item1, item2));
+    this.applyFilters(this.filterConfig.appliedFilters || []);
+  }
+
+  // Selection
+
+  handleSelectionChange($event: TableEvent): void {
+    this.actionsText = $event.selectedRows.length + ' rows selected\r\n' + this.actionsText;
+  }
+
+  updateItemsAvailable(): void {
+    if (this.rowsAvailable) {
+      this.toolbarConfig.filterConfig.totalCount = this.allRows.length;
+      this.filteredRows = this.allRows;
+      this.updateRows(false);
+    } else {
+      // Clear previously applied properties to simulate no rows available
+      this.toolbarConfig.filterConfig.totalCount = 0;
+      this.filterConfig.appliedFilters = [];
+      this.rows = [];
+    }
+  }
+}

--- a/src/app/table/basic-table/example/table-example.component.html
+++ b/src/app/table/basic-table/example/table-example.component.html
@@ -24,6 +24,9 @@
     <tab heading="Group Headers" (select)="tabSelected($event)">
       <table-group-example *ngIf="activeTab === 'Group Headers'"></table-group-example>
     </tab>
+    <tab heading="Empty Table" (select)="tabSelected($event)">
+      <table-empty-example *ngIf="activeTab === 'Empty Table'"></table-empty-example>
+    </tab>
     <tab heading="Full" (select)="tabSelected($event)">
       <table-full-example *ngIf="activeTab === 'Full'"></table-full-example>
     </tab>

--- a/src/app/table/basic-table/example/table-example.module.ts
+++ b/src/app/table/basic-table/example/table-example.module.ts
@@ -6,6 +6,7 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
+import { TableEmptyExampleComponent } from './table-empty-example.component';
 import { TableExampleComponent } from './table-example.component';
 import { TableBasicExampleComponent } from './table-basic-example.component';
 import { TableDndExampleComponent } from './table-dnd-example.component';
@@ -23,6 +24,7 @@ import { ToolbarModule } from '../../../toolbar/toolbar.module';
     TableBasicExampleComponent,
     TableDndExampleComponent,
     TableEmbeddedExampleComponent,
+    TableEmptyExampleComponent,
     TableExampleComponent,
     TableExpansionExampleComponent,
     TableFullExampleComponent,

--- a/src/app/table/basic-table/table.component.html
+++ b/src/app/table/basic-table/table.component.html
@@ -65,29 +65,29 @@
           <span class="pfng-list-expand-placeholder"></span>
         </span>
         <input type="checkbox" value="allRowsSelected" title="{{(allRowsSelected) ? 'Deselect' : 'Select'}} All Rows"
-               [disabled]="rows.length === 0"
+               [disabled]="rows === undefined || rows.length === 0"
                [(ngModel)]="allRowsSelected"
                (ngModelChange)="selectionsChange()"
                *ngIf="config.showCheckbox === true">
       </ng-template>
       <ng-template #selectCellTemplate let-row="row" let-expanded="expanded">
-      <span class="pfng-table-dnd-container" *ngIf="config.dragEnabled === true">
-        <span class="pfng-table-dnd-header"></span>
-      </span>
-      <span [ngClass]="{'margin-left-5': config.dragEnabled === true}"
-            *ngIf="config.useExpandRows === true">
-        <span class="pfng-list-expand-placeholder" *ngIf="row.hideExpandToggle === true"></span>
-        <span class="fa"
-              [ngClass]="{'fa-angle-down': expanded, 'fa-angle-right margin-right-4': !expanded}"
-              (click)="toggleExpandRow(row)"
-              *ngIf="row.hideExpandToggle !== true"></span>
-      </span>
-      <span [ngClass]="{'margin-left-5': config.dragEnabled === true || config.useExpandRows === true}"
-            *ngIf="config.showCheckbox === true">
-        <input type="checkbox" value="row.selected" title="{{(row.selected) ? 'Deselect' : 'Select'}} Row"
-               [(ngModel)]="row.selected"
-               (ngModelChange)="selectionChange(row)">
-      </span>
+        <span class="pfng-table-dnd-container" *ngIf="config.dragEnabled === true">
+          <span class="pfng-table-dnd-header"></span>
+        </span>
+        <span [ngClass]="{'margin-left-5': config.dragEnabled === true}"
+              *ngIf="config.useExpandRows === true">
+          <span class="pfng-list-expand-placeholder" *ngIf="row.hideExpandToggle === true"></span>
+          <span class="fa"
+                [ngClass]="{'fa-angle-down': expanded, 'fa-angle-right margin-right-4': !expanded}"
+                (click)="toggleExpandRow(row)"
+                *ngIf="row.hideExpandToggle !== true"></span>
+        </span>
+        <span [ngClass]="{'margin-left-5': config.dragEnabled === true || config.useExpandRows === true}"
+              *ngIf="config.showCheckbox === true">
+          <input type="checkbox" value="row.selected" title="{{(row.selected) ? 'Deselect' : 'Select'}} Row"
+                 [(ngModel)]="row.selected"
+                 (ngModelChange)="selectionChange(row)">
+        </span>
       </ng-template>
       <!-- Group header template -->
       <ngx-datatable-group-header [rowHeight]="dataTableConfig.rowHeight" *ngIf="groupHeaderTemplate !== undefined">


### PR DESCRIPTION
This change ensures a table can be loaded from an empty state.

- Forced change detection by re-initializing selection column.
- Fixed an issue where the toolbar is not disabled when the table is initially empty.
- Cleaned up indentation in HTML template.
- Created a new “Empty Table” example to test table in an initial empty state

Fixes: https://github.com/patternfly/patternfly-ng/issues/337

Demo: Choose the "Empty Table" tab and select the "Rows Available" checkbox
https://rawgit.com/dlabrecq/patternfly-ng/empty-table-dist/dist-demo/#/table