### PR TITLE
Refactored lists to use individual modules

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -59,17 +59,19 @@ export {
   FilterType
 } from './filter/index';
 
-// Lists
+// List
 export {
+  BasicListModule,
   ListBase,
   ListBaseConfig,
   ListConfig,
   ListComponent,
-  ListEvent,
-  ListModule,
   ListExpandToggleComponent,
+  ListEvent,
+  ListModule, // @deprecated Use BasicListModule or TreeListModule
   TreeListComponent,
-  TreeListConfig
+  TreeListConfig,
+  TreeListModule
 } from './list/index';
 
 // Modals

--- a/src/app/list/basic-list/example/list-example.module.ts
+++ b/src/app/list/basic-list/example/list-example.module.ts
@@ -12,7 +12,7 @@ import { ClustersContentComponent } from './content/clusters-content.component';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { HostsContentComponent } from './content/hosts-content.component';
 import { ImagesContentComponent } from './content/images-content.component';
-import { ListModule } from '../../list.module';
+import { ListModule } from '../list.module';
 import { ListBasicExampleComponent } from './list-basic-example.component';
 import { ListCompoundExampleComponent } from './list-compound-example.component';
 import { ListHeadingExampleComponent } from './list-heading-example.component';

--- a/src/app/list/basic-list/index.ts
+++ b/src/app/list/basic-list/index.ts
@@ -1,0 +1,5 @@
+export { ListComponent } from './list.component';
+export { ListConfig } from './list-config';
+export { ListExpandToggleComponent } from './list-expand-toggle.component';
+export { ListModule } from './list.module';
+export { ListModule as BasicListModule  } from './list.module';

--- a/src/app/list/basic-list/list.component.ts
+++ b/src/app/list/basic-list/list.component.ts
@@ -25,6 +25,12 @@ import { ListEvent } from '../list-event';
  *
  * Cannot use both multi-select and double click selection at the same time
  * Cannot use both checkbox and click selection at the same time
+ *
+ * Usage:
+ * <br/><code>import { BasicListModule } from 'patternfly-ng/list';</code>
+ *
+ * Or:
+ * <br/><code>import { BasicListModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/list/basic-list/list.module.ts
+++ b/src/app/list/basic-list/list.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { ListComponent } from './list.component';
+import { ListConfig } from './list-config';
+import { ListExpandToggleComponent } from './list-expand-toggle.component';
+import { PipeModule } from '../../pipe/pipe.module';
+
+export {
+  ListConfig,
+  ListExpandToggleComponent
+};
+
+/**
+ * A module containing objects associated with basic list components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    EmptyStateModule,
+    FormsModule,
+    PipeModule
+  ],
+  declarations: [ListComponent, ListExpandToggleComponent],
+  exports: [ListComponent, ListExpandToggleComponent]
+})
+export class ListModule {}

--- a/src/app/list/index.ts
+++ b/src/app/list/index.ts
@@ -1,9 +1,17 @@
 export { ListBase } from './list-base';
 export { ListBaseConfig } from './list-base-config';
-export { ListConfig } from './basic-list/list-config';
-export { ListComponent } from './basic-list/list.component';
 export { ListEvent } from './list-event';
-export { ListModule } from './list.module';
-export { ListExpandToggleComponent } from './basic-list/list-expand-toggle.component';
-export { TreeListComponent } from './tree-list/tree-list.component';
-export { TreeListConfig } from './tree-list/tree-list-config';
+
+export {
+  BasicListModule,
+  ListConfig,
+  ListComponent,
+  ListExpandToggleComponent,
+  ListModule // @deprecated Use BasicListModule or TreeListModule
+} from './basic-list/index';
+
+export {
+  TreeListComponent,
+  TreeListConfig,
+  TreeListModule
+} from './tree-list/index';

--- a/src/app/list/list.module.ts
+++ b/src/app/list/list.module.ts
@@ -2,19 +2,16 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TreeModule } from 'angular-tree-component';
-
-import { EmptyStateModule } from '../empty-state/empty-state.module';
 import { ListBase } from './list-base';
 import { ListBaseConfig } from './list-base-config';
 import { ListEvent } from './list-event';
 import { ListComponent } from './basic-list/list.component';
+import { ListModule as BasicListModule } from './basic-list/list.module';
 import { ListConfig } from './basic-list/list-config';
 import { ListExpandToggleComponent } from './basic-list/list-expand-toggle.component';
-import { PipeModule } from '../pipe/pipe.module';
 import { TreeListComponent } from './tree-list/tree-list.component';
 import { TreeListConfig } from './tree-list/tree-list-config';
+import { TreeListModule } from './tree-list/tree-list.module';
 
 export {
   ListBase,
@@ -26,18 +23,16 @@ export {
 
 /**
  * A module containing objects associated with list components
+ *
+ * @deprecated Use BasicListModule or TreeListModule
  */
 @NgModule({
   imports: [
-    BsDropdownModule.forRoot(),
+    BasicListModule,
     CommonModule,
-    EmptyStateModule,
     FormsModule,
-    PipeModule,
-    TreeModule
+    TreeListModule
   ],
-  declarations: [ListComponent, ListExpandToggleComponent, TreeListComponent],
-  exports: [ListComponent, ListExpandToggleComponent, TreeListComponent],
-  providers: [BsDropdownConfig]
+  exports: [ListComponent, ListExpandToggleComponent, TreeListComponent]
 })
 export class ListModule {}

--- a/src/app/list/tree-list/example/tree-list-example.module.ts
+++ b/src/app/list/tree-list/example/tree-list-example.module.ts
@@ -10,7 +10,7 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
 import { TreeListBasicExampleComponent } from './tree-list-basic-example.component';
 import { TreeListDndExampleComponent } from './tree-list-dnd-example.component';
 import { TreeListExampleComponent } from './tree-list-example.component';
-import { ListModule } from '../../list.module';
+import { TreeListModule } from '../tree-list.module';
 
 @NgModule({
   declarations: [
@@ -24,7 +24,7 @@ import { ListModule } from '../../list.module';
     DemoComponentsModule,
     FormsModule,
     TabsModule.forRoot(),
-    ListModule,
+    TreeListModule,
     TreeModule
   ],
   providers: [TabsetConfig]

--- a/src/app/list/tree-list/index.ts
+++ b/src/app/list/tree-list/index.ts
@@ -1,0 +1,3 @@
+export { TreeListComponent } from './tree-list.component';
+export { TreeListConfig } from './tree-list-config';
+export { TreeListModule } from './tree-list.module';

--- a/src/app/list/tree-list/tree-list.component.ts
+++ b/src/app/list/tree-list/tree-list.component.ts
@@ -28,6 +28,12 @@ import { TreeListConfig } from './tree-list-config';
  * Cannot use both checkbox and click selection at the same time
  *
  * For angular-tree-component options, see: https://angular2-tree.readme.io/docs
+ *
+ * Usage:
+ * <br/><code>import { TreeListModule } from 'patternfly-ng/list';</code>
+ *
+ * Or:
+ * <br/><code>import { TreeListModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/list/tree-list/tree-list.module.ts
+++ b/src/app/list/tree-list/tree-list.module.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { TreeListComponent } from './tree-list.component';
+import { TreeListConfig } from './tree-list-config';
+import { TreeModule } from 'angular-tree-component';
+
+export {
+  TreeListConfig
+};
+
+/**
+ * A module containing objects associated with tree list components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    EmptyStateModule,
+    FormsModule,
+    TreeModule
+  ],
+  declarations: [TreeListComponent],
+  exports: [TreeListComponent]
+})
+export class TreeListModule {}


### PR DESCRIPTION
This allows for the basic list to be imported without the angular-tree-component dependency, required by tree list.

The user can now import individual modules like so:

```
import { BasicListModule } from 'patternfly-ng/list';
import { TreeListModule } from 'patternfly-ng/list';
```

Or

`import { BasicListModule, TreeListModule } from 'patternfly-ng';`

If this looks good, I’d like to create individual modules for all components so dependencies can truly be optional.

Example:
https://rawgit.com/dlabrecq/patternfly-ng/list-module-dist/dist-demo/#/list

Deprecations:
```
ListModule  -- Use BasicListModule and TreeListModule
```