### PR TITLE
Refactored cards to use individual modules

### DIFF
--- a/src/app/card/basic-card/card.component.ts
+++ b/src/app/card/basic-card/card.component.ts
@@ -20,6 +20,12 @@ import { CardFilterPosition } from '../card-filter/card-filter-position';
  * Card component
  *
  * For customization, use the templates named headerTemplate and footerTemplate.
+ *
+ * Usage:
+ * <br/><code>import { BasicCardModule } from 'patternfly-ng/card';</code>
+ *
+ * Or:
+ * <br/><code>import { BasicCardModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/card/basic-card/card.module.ts
+++ b/src/app/card/basic-card/card.module.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { CardActionModule } from '../card-action/card-action.module';
+import { CardComponent } from '../basic-card/card.component';
+import { CardConfig } from '../basic-card/card-config';
+import { CardFilterModule } from '../card-filter/card-filter.module';
+
+export {
+  CardConfig
+};
+
+/**
+ * A module containing objects associated with basic card components
+ */
+@NgModule({
+  imports: [
+    CardActionModule,
+    CardFilterModule,
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [CardComponent],
+  exports: [CardComponent]
+})
+export class CardModule {}

--- a/src/app/card/basic-card/example/card-example.module.ts
+++ b/src/app/card/basic-card/example/card-example.module.ts
@@ -2,10 +2,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { CardModule } from '../../card.module';
+import { CardModule } from '../card.module';
 import { CardBasicExampleComponent } from './card-basic-example.component';
 import { CardCustomExampleComponent } from './card-custom-example.component';
 import { CardExampleComponent } from './card-example.component';
@@ -21,7 +20,6 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
     CardTrendExampleComponent
   ],
   imports: [
-    BsDropdownModule.forRoot(),
     CardModule,
     ChartModule,
     CommonModule,
@@ -29,7 +27,7 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
     FormsModule,
     TabsModule.forRoot()
   ],
-  providers: [BsDropdownConfig, TabsetConfig]
+  providers: [TabsetConfig]
 })
 export class CardExampleModule {
   constructor() {}

--- a/src/app/card/basic-card/index.ts
+++ b/src/app/card/basic-card/index.ts
@@ -1,0 +1,4 @@
+export { CardComponent } from './card.component';
+export { CardConfig } from './card-config';
+export { CardModule } from './card.module';
+export { CardModule as BasicCardModule } from './card.module';

--- a/src/app/card/card-action/card-action.component.ts
+++ b/src/app/card/card-action/card-action.component.ts
@@ -11,6 +11,12 @@ import { CardAction } from './card-action';
 
 /**
  * Card action component
+ *
+ * Usage:
+ * <br/><code>import { CardActionModule } from 'patternfly-ng/card';</code>
+ *
+ * Or:
+ * <br/><code>import { CardActionModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/card/card-action/card-action.module.ts
+++ b/src/app/card/card-action/card-action.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { CardAction } from './card-action';
+import { CardActionComponent } from './card-action.component';
+
+export {
+  CardAction
+};
+
+/**
+ * A module containing objects associated with card action components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [CardActionComponent],
+  exports: [CardActionComponent]
+})
+export class CardActionModule {}

--- a/src/app/card/card-action/index.ts
+++ b/src/app/card/card-action/index.ts
@@ -1,0 +1,3 @@
+export { CardAction } from './card-action';
+export { CardActionComponent } from './card-action.component';
+export { CardActionModule } from './card-action.module';

--- a/src/app/card/card-filter/card-filter.component.ts
+++ b/src/app/card/card-filter/card-filter.component.ts
@@ -11,6 +11,12 @@ import { CardFilter } from '../card-filter/card-filter';
 
 /**
  * Card filter component
+ *
+ * Usage:
+ * <br/><code>import { CardFilterModule } from 'patternfly-ng/card';</code>
+ *
+ * Or:
+ * <br/><code>import { CardFilterModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/card/card-filter/card-filter.module.ts
+++ b/src/app/card/card-filter/card-filter.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { CardFilter } from './card-filter';
+import { CardFilterComponent } from './card-filter.component';
+import { CardFilterPosition } from './card-filter-position';
+
+export {
+  CardFilter,
+  CardFilterPosition
+};
+
+/**
+ * A module containing objects associated with card filter components
+ */
+@NgModule({
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [CardFilterComponent],
+  exports: [CardFilterComponent],
+  providers: [BsDropdownConfig]
+})
+export class CardFilterModule {}

--- a/src/app/card/card-filter/index.ts
+++ b/src/app/card/card-filter/index.ts
@@ -1,0 +1,4 @@
+export { CardFilter } from './card-filter';
+export { CardFilterComponent } from './card-filter.component';
+export { CardFilterPosition } from './card-filter-position';
+export { CardFilterModule } from './card-filter.module';

--- a/src/app/card/card.module.ts
+++ b/src/app/card/card.module.ts
@@ -2,10 +2,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
-
 import { CardAction } from './card-action/card-action';
-import { CardActionComponent } from './card-action/card-action.component';
 import { CardBase } from './card-base';
 import { CardComponent } from './basic-card/card.component';
 import { CardConfig } from './basic-card/card-config';
@@ -13,8 +10,13 @@ import { CardConfigBase } from './card-config-base';
 import { CardFilter } from './card-filter/card-filter';
 import { CardFilterComponent } from './card-filter/card-filter.component';
 import { CardFilterPosition } from './card-filter/card-filter-position';
-import { InfoStatusCardConfig } from './info-status-card/info-status-card-config';
 import { InfoStatusCardComponent } from './info-status-card/info-status-card.component';
+import { InfoStatusCardConfig } from './info-status-card/info-status-card-config';
+import { InfoStatusCardModule } from './info-status-card/info-status-card.module';
+
+import { CardActionModule } from './card-action/card-action.module';
+import { CardModule as BasicCardModule} from './basic-card/card.module';
+import { CardFilterModule } from './card-filter/card-filter.module';
 
 export {
   CardAction,
@@ -28,15 +30,18 @@ export {
 
 /**
  * A module containing objects associated with card components
+ *
+ * @deprecated Use BasicCardModule or InfoStatusCardModule
  */
 @NgModule({
   imports: [
-    BsDropdownModule.forRoot(),
+    BasicCardModule,
+    CardActionModule,
+    CardFilterModule,
     CommonModule,
-    FormsModule
+    FormsModule,
+    InfoStatusCardModule
   ],
-  declarations: [CardActionComponent, CardComponent, CardFilterComponent, InfoStatusCardComponent],
-  exports: [CardComponent, CardFilterComponent, InfoStatusCardComponent],
-  providers: [BsDropdownConfig]
+  exports: [CardComponent, CardFilterComponent, InfoStatusCardComponent]
 })
 export class CardModule {}

--- a/src/app/card/index.ts
+++ b/src/app/card/index.ts
@@ -1,12 +1,28 @@
-export { CardAction } from './card-action/card-action';
-export { CardActionComponent } from './card-action/card-action.component';
 export { CardBase } from './card-base';
-export { CardConfig } from './basic-card/card-config';
 export { CardConfigBase } from './card-config-base';
-export { CardComponent } from './basic-card/card.component';
-export { CardFilter } from './card-filter/card-filter';
-export { CardFilterComponent } from './card-filter/card-filter.component';
-export { CardFilterPosition } from './card-filter/card-filter-position';
 export { CardModule } from './card.module';
-export { InfoStatusCardComponent } from './info-status-card/info-status-card.component';
-export { InfoStatusCardConfig } from './info-status-card/info-status-card-config';
+
+export {
+  CardAction,
+  CardActionComponent,
+  CardActionModule
+} from './card-action/index';
+
+export {
+  BasicCardModule,
+  CardComponent,
+  CardConfig
+} from './basic-card/index';
+
+export {
+  CardFilter,
+  CardFilterComponent,
+  CardFilterModule,
+  CardFilterPosition,
+} from './card-filter/index';
+
+export {
+  InfoStatusCardComponent,
+  InfoStatusCardConfig,
+  InfoStatusCardModule
+} from './info-status-card/index';

--- a/src/app/card/info-status-card/example/info-status-card-example.module.ts
+++ b/src/app/card/info-status-card/example/info-status-card-example.module.ts
@@ -2,10 +2,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { CardModule } from '../../card.module';
+import { InfoStatusCardModule } from '../info-status-card.module';
 import { InfoStatusCardExampleComponent } from './info-status-card-example.component';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 
@@ -14,14 +13,13 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
     InfoStatusCardExampleComponent
   ],
   imports: [
-    BsDropdownModule.forRoot(),
-    CardModule,
     CommonModule,
     DemoComponentsModule,
     FormsModule,
+    InfoStatusCardModule,
     TabsModule.forRoot()
   ],
-  providers: [ BsDropdownConfig, TabsetConfig ]
+  providers: [ TabsetConfig ]
 })
 export class InfoStatusCardExampleModule {
   constructor() {}

--- a/src/app/card/info-status-card/index.ts
+++ b/src/app/card/info-status-card/index.ts
@@ -1,0 +1,3 @@
+export { InfoStatusCardComponent } from './info-status-card.component';
+export { InfoStatusCardConfig } from './info-status-card-config';
+export { InfoStatusCardModule } from './info-status-card.module';

--- a/src/app/card/info-status-card/info-status-card.component.ts
+++ b/src/app/card/info-status-card/info-status-card.component.ts
@@ -12,14 +12,18 @@ import { InfoStatusCardConfig } from './info-status-card-config';
 
 /**
  * Info Status Card Component
+ *
+ * Usage:
+ * <br/><code>import { InfoStatusCardModule } from 'patternfly-ng/card';</code>
+ *
+ * Or:
+ * <br/><code>import { InfoStatusCardModule } from 'patternfly-ng';</code>
  */
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'pfng-info-status-card',
   templateUrl: './info-status-card.component.html'
-
 })
-
 export class InfoStatusCardComponent implements OnInit, DoCheck {
 
   /**

--- a/src/app/card/info-status-card/info-status-card.module.ts
+++ b/src/app/card/info-status-card/info-status-card.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { InfoStatusCardConfig } from './info-status-card-config';
+import { InfoStatusCardComponent } from './info-status-card.component';
+
+export {
+  InfoStatusCardConfig
+};
+
+/**
+ * A module containing objects associated with info status card components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [InfoStatusCardComponent],
+  exports: [InfoStatusCardComponent]
+})
+export class InfoStatusCardModule {}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -10,18 +10,22 @@ export {
 
 // Cards
 export {
+  BasicCardModule,
   CardAction,
   CardActionComponent,
+  CardActionModule,
   CardBase,
+  CardComponent,
   CardConfig,
   CardConfigBase,
-  CardComponent,
   CardFilter,
   CardFilterComponent,
+  CardFilterModule,
   CardFilterPosition,
-  CardModule,
+  CardModule, // @deprecated Use BasicCardModule or InfoStatusCardModule
   InfoStatusCardComponent,
-  InfoStatusCardConfig
+  InfoStatusCardConfig,
+  InfoStatusCardModule
 } from './card/index';
 
 // Charts


### PR DESCRIPTION
Similar to the refactored list modules, this change allows each card to be imported individually.

The user can now import individual modules like so:

```
import { BasicCardModule } from 'patternfly-ng/card';
import { InfoStatusCardModule } from 'patternfly-ng/card';
```

Or

```
import {  BasicCardModule,  InfoStatusCardModule } from 'patternfly-ng';
```

Example:
https://rawgit.com/dlabrecq/patternfly-ng/card-module-dist/dist-demo/#/card

Deprecations:
```
CardModule  -- Use BasicCardModule or InfoStatusCardModule
```