### PR TITLE
Open peer dependencies to include angular 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,15 @@
     "angular 2",
     "angular4",
     "angular 4",
+    "angular5",
+    "angular 5",
+    "angular6",
+    "angular 6",
     "ng",
     "ng2",
-    "ng4"
+    "ng4",
+    "ng5",
+    "ng6"
   ],
   "homepage": "https://github.com/patternfly/patternfly-ng",
   "repository": {
@@ -59,10 +65,10 @@
     "npm": ">=5.3.0"
   },
   "peerDependencies": {
-    "@angular/common": ">=4.0.1 || >5.0.0",
-    "@angular/compiler": ">=4.0.1 || >5.0.0",
-    "@angular/core": ">=4.0.1 || >5.0.0",
-    "@angular/forms": ">=4.0.1 || >5.0.0",
+    "@angular/common": ">=4.0.1 || >5.0.0 || >6.0.0",
+    "@angular/compiler": ">=4.0.1 || >5.0.0 || >6.0.0",
+    "@angular/core": ">=4.0.1 || >5.0.0 || >6.0.0",
+    "@angular/forms": ">=4.0.1 || >5.0.0 || >6.0.0",
     "typescript": ">=2.3.4",
     "rxjs": ">=5.0.1"
   },


### PR DESCRIPTION
Tested using the latest angular-cli and built with `ng --prod`. My Angular 6 based app built and ran patternfly-ng components without error.

Note that angular-cli isn't without its own issues. I encountered this problem along the way, but was able to apply the suggested workaround.
https://github.com/aws/aws-amplify/issues/678

The angular-cli application also required rxjs-compat 6.1.0.