### PR TITLE
Support rxjs v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "angular-tree-component": "^6.0.0 || ^7.0.0",
     "c3": "^0.4.15",
     "ng2-dragula": "^1.5.0",
-    "ngx-bootstrap": "^1.8.0 || ^2.0.0"
+    "ngx-bootstrap": "^1.8.0 || ^2.0.0",
+    "rxjs-compat": "^6.1.0"
   },
   "devDependencies": {
     "@angular/animations": "^4.0.1",


### PR DESCRIPTION
Angular v6 started requiring rxjs v6 which has changed import locations. ngx-bootstrap v2 does not support rxjs v6, so as a work-around, we can install rxjs-compat to get Patternfly to work with Angular v6.

When you feel comfortable, you could alternatively upgrade ngx-bootstrap to v3. Here is the backstory on that:
https://github.com/valor-software/ngx-bootstrap/issues/4308