### PR TITLE
List: add unique element IDs

### DIFF
--- a/src/app/list/basic-list/example/list-basic-example.component.html
+++ b/src/app/list/basic-list/example/list-basic-example.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-12">
       <div class="form-group">
-        <pfng-list
+        <pfng-list id="myList"
             [actionTemplate]="actionTemplate"
             [config]="listConfig"
             [expandTemplate]="expandTemplate"

--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -35,7 +35,7 @@
   <div class="list-pf-item {{item?.itemStyleClass}}"
        [ngClass]="{'active': item.selected || item.isItemExpanded}"
        *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
-    <div class="list-pf-container">
+    <div class="list-pf-container" [id]="getId('item', i)">
       <!-- pin -->
       <div class="pfng-list-pin-container" *ngIf="config.usePinItems">
         <div class="pfng-list-pin-placeholder"
@@ -61,12 +61,14 @@
       <!-- checkbox -->
       <div class="list-pf-select" *ngIf="config.showCheckbox && !config.showRadioButton">
         <input type="checkbox"
+               [id]="getId('checkbox', i)"
                [(ngModel)]="item.selected"
                (ngModelChange)="checkboxChange(item)">
       </div>
       <!-- radio button -->
       <div class="list-pf-select" *ngIf="!config.showCheckbox && config.showRadioButton">
         <input type="radio"
+               [id]="getId('radio', i)"
                [checked]="item.selected"
                (click)="radioButtonChange(item)">
       </div>

--- a/src/app/list/basic-list/list.component.ts
+++ b/src/app/list/basic-list/list.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   DoCheck,
+  ElementRef,
   EventEmitter,
   Input,
   OnInit,
@@ -9,7 +10,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { cloneDeep, defaults, isEqual } from 'lodash';
+import { cloneDeep, defaults, isEqual, uniqueId } from 'lodash';
 
 import { ListBase } from '../list-base';
 import { ListConfig } from './list-config';
@@ -25,6 +26,8 @@ import { ListEvent } from '../list-event';
  *
  * Cannot use both multi-select and double click selection at the same time
  * Cannot use both checkbox and click selection at the same time
+ *
+ * Unique IDs are generated for each list item, which can be overridden by providing an id for the pfng-list tag.
  *
  * Usage:
  * <br/><code>import { BasicListModule } from 'patternfly-ng/list';</code>
@@ -74,12 +77,13 @@ export class ListComponent extends ListBase implements DoCheck, OnInit {
     showRadioButton: false,
     useExpandItems: false
   } as ListConfig;
+  private id: string = uniqueId('pfng-list');
   private prevConfig: ListConfig;
 
   /**
    * The default constructor
    */
-  constructor() {
+  constructor(private el: ElementRef) {
     super();
   }
 
@@ -122,6 +126,23 @@ export class ListComponent extends ListBase implements DoCheck, OnInit {
    */
   protected getConfig(): ListConfig {
     return this.config;
+  }
+
+  /**
+   * Return an ID for the given element prefix and index (e.g., 'pfng-list1-item0')
+   *
+   * Note: The ID prefix can be overridden by providing an id for the pfng-list tag.
+   *
+   * @param {string} suffix The element suffix (e.g., 'item')
+   * @param {number} index The current item index
+   * @returns {string}
+   */
+  protected getId(suffix: string, index: number): string {
+    let result = this.id;
+    if (this.el.nativeElement.id !== undefined && this.el.nativeElement.id.length > 0) {
+      result = this.el.nativeElement.id;
+    }
+    return result + '-' + suffix + index;
   }
 
   // Toggle


### PR DESCRIPTION
This adds unique element IDs for each row, checkbox, and radio button. Default IDs can be overridden by providing an id for the pfng-list tag.

Example
https://rawgit.com/dlabrecq/patternfly-ng/list-ids-dist/dist-demo/#/list

Fixes: https://github.com/patternfly/patternfly-ng/issues/348

![screen shot 2018-05-22 at 8 49 50 pm](https://user-images.githubusercontent.com/17481322/40397653-c1e80110-5e01-11e8-983a-96c6cde56d4e.png)
