### PR TITLE
fix(list): make more areas clickable for expansion and add hover styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .DS_Store
+.vscode
 dist
 dist-demo
 node_modules

--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -35,7 +35,7 @@
   <div class="list-pf-item {{item?.itemStyleClass}}"
        [ngClass]="{'active': item.selected || item.isItemExpanded}"
        *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
-    <div class="list-pf-container" [id]="getId('item', i)">
+    <div class="list-pf-container" [id]="getId('item', i)" (click)="toggleExpandArea($event, item)">
       <!-- pin -->
       <div class="pfng-list-pin-container" *ngIf="config.usePinItems">
         <div class="pfng-list-pin-placeholder"
@@ -55,7 +55,7 @@
         <div class="pfng-list-expand-placeholder" *ngIf="item.hideExpandToggle === true"></div>
         <span class="fa fa-angle-right"
               *ngIf="item.hideExpandToggle !== true"
-              (click)="toggleExpandArea(item)"
+              (click)="toggleExpandArea($event, item)"
               [ngClass]="{'fa-angle-down': item.expanded && item.expandId === undefined}"></span>
       </div>
       <!-- checkbox -->

--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -35,7 +35,10 @@
   <div class="list-pf-item {{item?.itemStyleClass}}"
        [ngClass]="{'active': item.selected || item.isItemExpanded}"
        *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
-    <div class="list-pf-container" [id]="getId('item', i)">
+    <div class="list-pf-container"
+         [ngClass]="{'pfng-list-item-expandable': config.useExpandItems}"
+         [id]="getId('item', i)" 
+         (click)="toggleExpandArea($event, item)">
       <!-- pin -->
       <div class="pfng-list-pin-container" *ngIf="config.usePinItems">
         <div class="pfng-list-pin-placeholder"
@@ -55,7 +58,7 @@
         <div class="pfng-list-expand-placeholder" *ngIf="item.hideExpandToggle === true"></div>
         <span class="fa fa-angle-right"
               *ngIf="item.hideExpandToggle !== true"
-              (click)="toggleExpandArea(item)"
+              (click)="toggleExpandArea($event, item)"
               [ngClass]="{'fa-angle-down': item.expanded && item.expandId === undefined}"></span>
       </div>
       <!-- checkbox -->

--- a/src/app/list/basic-list/list.component.less
+++ b/src/app/list/basic-list/list.component.less
@@ -23,6 +23,16 @@
   }
 }
 
+.list-pf-container {
+  // Add hover style and modify cursor
+  .list-pf-chevron {
+    cursor: pointer;
+    &:hover {
+      color: @color-pf-blue-400;
+    }
+  }
+}
+
 // For displaying close button in expansion area
 .pfng-list-expansion {
   position: relative;

--- a/src/app/list/basic-list/list.component.less
+++ b/src/app/list/basic-list/list.component.less
@@ -23,6 +23,13 @@
   }
 }
 
+.list-pf-chevron {
+  cursor: pointer;
+  &:hover {
+    color: @color-pf-blue-400;
+  }
+}
+
 // For displaying close button in expansion area
 .pfng-list-expansion {
   position: relative;

--- a/src/app/list/basic-list/list.component.ts
+++ b/src/app/list/basic-list/list.component.ts
@@ -152,7 +152,17 @@ export class ListComponent extends ListBase implements DoCheck, OnInit {
     item.expanded = false;
   }
 
-  private toggleExpandArea(item: any): void {
+  /**
+   * Toggles the list item expansion
+   * 
+   * @param {MouseEvent} $event The event emitted when an item has been clicked
+   * @param {Object} item The object associated with the current row
+   */
+  private toggleExpandArea($event: any, item: any): void {
+    // Do nothing if item expansion is disabled
+    if (!this.config.useExpandItems) return;
+    // Do not trigger for child items, only on the DOM element to which the event is attached
+    if ($event.target !== $event.currentTarget) return;
     // Item may already be open due to compound expansion
     if (item.expanded && item.expandId !== undefined) {
       item.expandId = undefined;

--- a/src/app/list/basic-list/list.component.ts
+++ b/src/app/list/basic-list/list.component.ts
@@ -158,11 +158,15 @@ export class ListComponent extends ListBase implements DoCheck, OnInit {
    * @param {MouseEvent} $event The event emitted when an item has been clicked
    * @param {Object} item The object associated with the current row
    */
-  private toggleExpandArea($event: any, item: any): void {
+  private toggleExpandArea($event: MouseEvent, item: any): void {
     // Do nothing if item expansion is disabled
-    if (!this.config.useExpandItems) return;
+    if (!this.config.useExpandItems) {
+      return;
+    }
     // Do not trigger for child items, only on the DOM element to which the event is attached
-    if ($event.target !== $event.currentTarget) return;
+    if ($event.target !== $event.currentTarget) {
+      return;
+    }
     // Item may already be open due to compound expansion
     if (item.expanded && item.expandId !== undefined) {
       item.expandId = undefined;


### PR DESCRIPTION
Addresses https://github.com/patternfly/patternfly-ng/issues/317

The border of the list item as well as the area around the left chevron is now also clickable if expansion is enabled.
Also the chevron now changes color on hover over (tested for basic list expansion, compound expansion, tree list).