### PR TITLE
fix(list): set list item active when expanded

### DIFF
--- a/src/app/list/basic-list/list.component.html
+++ b/src/app/list/basic-list/list.component.html
@@ -33,7 +33,7 @@
   </div>
   <!-- items -->
   <div class="list-pf-item {{item?.itemStyleClass}}"
-       [ngClass]="{'active': item.selected || item.isItemExpanded}"
+       [ngClass]="{'active': item.selected || item.expanded}"
        *ngFor="let item of (config.usePinItems ? (items | sortArray: 'showPin': true) : items); let i = index">
     <div class="list-pf-container" [id]="getId('item', i)">
       <!-- pin -->


### PR DESCRIPTION
Addresses issue in https://github.com/patternfly/patternfly-ng/issues/333

Change:
When a list item is expanded, the correct boolean variable is used to set the active class on list items.

Note:
There will be another PR to patternfly-core to address the .list-pf-item.active class such as background-color and box-shadow.

Travis build:
https://rawgit.com/jschuler/patternfly-ng/list-item-active-dist/dist-demo/#/list