### PR TITLE
Deprecate tree-list

### DIFF
--- a/src/app/list/tree-list/example/tree-list-example.component.html
+++ b/src/app/list/tree-list/example/tree-list-example.component.html
@@ -1,7 +1,7 @@
 <div class="padding-15">
   <div class="row">
     <div class="col-sm-12">
-      <h4>Tree List Component Example</h4>
+      <h4>Tree List Component Example (deprecated)</h4>
       <hr/>
     </div>
   </div>

--- a/src/app/list/tree-list/tree-list-config.ts
+++ b/src/app/list/tree-list/tree-list-config.ts
@@ -2,6 +2,11 @@ import { ListConfigBase } from '../list-config-base';
 
 /**
  * A config containing properties for tree list
+ *
+ * @deprecated The tree-list component is deprecated due to issues with Angular 6 and mobx autorun,
+ * introduced by angular-tree-component.
+ *
+ * See: https://github.com/patternfly/patternfly-ng/issues/381
  */
 export class TreeListConfig extends ListConfigBase {
   /**

--- a/src/app/list/tree-list/tree-list.component.ts
+++ b/src/app/list/tree-list/tree-list.component.ts
@@ -34,6 +34,11 @@ import { TreeListConfig } from './tree-list-config';
  *
  * Or:
  * <br/><code>import { TreeListModule } from 'patternfly-ng';</code>
+ *
+ * @deprecated The tree-list component is deprecated due to issues with Angular 6 and mobx autorun,
+ * introduced by angular-tree-component.
+ *
+ * See: https://github.com/patternfly/patternfly-ng/issues/381
  */
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/list/tree-list/tree-list.module.ts
+++ b/src/app/list/tree-list/tree-list.module.ts
@@ -9,6 +9,11 @@ import { TreeListComponent } from './tree-list.component';
 
 /**
  * A module containing objects associated with tree list components
+ *
+ * @deprecated The tree-list component is deprecated due to issues with Angular 6 and mobx autorun,
+ * introduced by angular-tree-component.
+ *
+ * See: https://github.com/patternfly/patternfly-ng/issues/381
  */
 @NgModule({
   imports: [
@@ -20,4 +25,9 @@ import { TreeListComponent } from './tree-list.component';
   declarations: [TreeListComponent],
   exports: [TreeListComponent]
 })
-export class TreeListModule {}
+export class TreeListModule {
+  constructor() {
+    console.log('patternfly-ng: The tree-list component is deprecated due to issues with Angular 6 and ' +
+      'mobx autorun, introduced by angular-tree-component.');
+  }
+}


### PR DESCRIPTION
Deprecated the tree-list component in anticipation of Angular 6 support.

Fixes https://github.com/patternfly/patternfly-ng/issues/381