### PR TITLE
Individual module imports for all components (backed out)

### DIFF
--- a/src/app/action/action.component.spec.ts
+++ b/src/app/action/action.component.spec.ts
@@ -76,7 +76,7 @@ describe('Action component - ', () => {
       declarations: [
         ActionComponent
       ],
-      providers: [BsDropdownConfig, TooltipConfig]
+      providers: [ BsDropdownConfig, TooltipConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/action/action.module.ts
+++ b/src/app/action/action.module.ts
@@ -22,8 +22,8 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [ActionComponent],
-  exports: [ActionComponent],
-  providers: [BsDropdownConfig]
+  declarations: [ ActionComponent ],
+  exports: [ ActionComponent ],
+  providers: [ BsDropdownConfig ]
 })
 export class ActionModule {}

--- a/src/app/action/example/action-example.module.ts
+++ b/src/app/action/example/action-example.module.ts
@@ -22,7 +22,7 @@ import { DemoComponentsModule } from '../../../demo/components/demo-components.m
     DemoComponentsModule,
     TabsModule.forRoot()
   ],
-  providers: [BsDropdownConfig, TabsetConfig]
+  providers: [ BsDropdownConfig, TabsetConfig ]
 })
 export class ActionExampleModule {
   constructor() {}

--- a/src/app/card/basic-card/card.module.ts
+++ b/src/app/card/basic-card/card.module.ts
@@ -2,13 +2,19 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
+import { CardAction } from '../card-action/card-action';
 import { CardActionModule } from '../card-action/card-action.module';
 import { CardComponent } from '../basic-card/card.component';
 import { CardConfig } from '../basic-card/card-config';
+import { CardFilter } from '../card-filter/card-filter';
 import { CardFilterModule } from '../card-filter/card-filter.module';
+import { CardFilterPosition } from '../card-filter/card-filter-position';
 
 export {
-  CardConfig
+  CardAction,
+  CardConfig,
+  CardFilter,
+  CardFilterPosition
 };
 
 /**
@@ -21,7 +27,7 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [CardComponent],
-  exports: [CardComponent]
+  declarations: [ CardComponent ],
+  exports: [ CardComponent ]
 })
 export class CardModule {}

--- a/src/app/card/basic-card/example/card-basic-example.component.ts
+++ b/src/app/card/basic-card/example/card-basic-example.component.ts
@@ -7,8 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
-import { SparklineConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
-import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-data';
+import { SparklineChartConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
+import { SparklineChartData } from '../../../chart/sparkline-chart/sparkline-chart-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -18,12 +18,12 @@ import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-da
 export class CardBasicExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfig: SparklineConfig = {
+  chartConfig: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'exampleSparkline',
     tooltipType: 'default'
   };
-  chartData: SparklineData = {
+  chartData: SparklineChartData = {
     dataAvailable: true,
     total: 100,
     xData: this.chartDates,

--- a/src/app/card/basic-card/example/card-example.module.ts
+++ b/src/app/card/basic-card/example/card-example.module.ts
@@ -27,7 +27,7 @@ import { SparklineChartModule } from '../../../chart/sparkline-chart/sparkline-c
     SparklineChartModule,
     TabsModule.forRoot()
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class CardExampleModule {
   constructor() {}

--- a/src/app/card/basic-card/example/card-trend-example.component.ts
+++ b/src/app/card/basic-card/example/card-trend-example.component.ts
@@ -7,8 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
-import { SparklineConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
-import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-data';
+import { SparklineChartConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
+import { SparklineChartData } from '../../../chart/sparkline-chart/sparkline-chart-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -18,12 +18,12 @@ import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-da
 export class CardTrendExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfigVirtual: SparklineConfig = {
+  chartConfigVirtual: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'virtualTrendsChart',
     tooltipType: 'default'
   };
-  chartDataVirtual: SparklineData = {
+  chartDataVirtual: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -31,12 +31,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '90', '20', '30', '20', '20', '10', '14', '20', '25',
       '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
   };
-  chartConfigPhysical: SparklineConfig = {
+  chartConfigPhysical: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'physicalTrendsChart',
     tooltipType: 'default'
   };
-  chartDataPhysical: SparklineData = {
+  chartDataPhysical: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -44,12 +44,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '20', '20', '35', '20', '20', '87', '14', '20', '25',
       '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
   };
-  chartConfigMemory: SparklineConfig = {
+  chartConfigMemory: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'memoryTrendsChart',
     tooltipType: 'default'
   };
-  chartDataMemory: SparklineData = {
+  chartDataMemory: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,

--- a/src/app/card/basic-card/index.ts
+++ b/src/app/card/basic-card/index.ts
@@ -1,4 +1,3 @@
 export { CardComponent } from './card.component';
 export { CardConfig } from './card-config';
 export { CardModule } from './card.module';
-export { CardModule as BasicCardModule } from './card.module';

--- a/src/app/card/card-action/card-action.module.ts
+++ b/src/app/card/card-action/card-action.module.ts
@@ -17,7 +17,7 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [CardActionComponent],
-  exports: [CardActionComponent]
+  declarations: [ CardActionComponent ],
+  exports: [ CardActionComponent ]
 })
 export class CardActionModule {}

--- a/src/app/card/card-filter/card-filter.module.ts
+++ b/src/app/card/card-filter/card-filter.module.ts
@@ -22,8 +22,8 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [CardFilterComponent],
-  exports: [CardFilterComponent],
-  providers: [BsDropdownConfig]
+  declarations: [ CardFilterComponent ],
+  exports: [ CardFilterComponent ],
+  providers: [ BsDropdownConfig ]
 })
 export class CardFilterModule {}

--- a/src/app/card/card.module.ts
+++ b/src/app/card/card.module.ts
@@ -31,7 +31,12 @@ export {
 /**
  * A module containing objects associated with card components
  *
- * @deprecated Use BasicCardModule or InfoStatusCardModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   CardModule, // basic card only
+ *   InfoStatusCardModule
+ * } from 'patternfy/card';
  */
 @NgModule({
   imports: [
@@ -42,6 +47,10 @@ export {
     FormsModule,
     InfoStatusCardModule
   ],
-  exports: [CardComponent, CardFilterComponent, InfoStatusCardComponent]
+  exports: [ CardComponent, CardFilterComponent, InfoStatusCardComponent ]
 })
-export class CardModule {}
+export class CardModule {
+  constructor() {
+    console.log('patternfly-ng: CardModule is deprecated; use InfoStatusCardModule or CardModule for basic card only');
+  }
+}

--- a/src/app/card/index.ts
+++ b/src/app/card/index.ts
@@ -1,6 +1,6 @@
 export { CardBase } from './card-base';
 export { CardConfigBase } from './card-config-base';
-export { CardModule } from './card.module';
+export { CardModule } from './card.module'; // @deprecated
 
 export * from './card-action/index';
 export * from './basic-card/index';

--- a/src/app/card/info-status-card/info-status-card.component.spec.ts
+++ b/src/app/card/info-status-card/info-status-card.component.spec.ts
@@ -15,7 +15,7 @@ describe('Info Status Card Component - ', () => {
     infoCard = new InfoStatusCardComponent();
 
     TestBed.configureTestingModule({
-      declarations: [InfoStatusCardComponent]
+      declarations: [ InfoStatusCardComponent ]
     })
     .compileComponents()
     .then(() => {

--- a/src/app/card/info-status-card/info-status-card.module.ts
+++ b/src/app/card/info-status-card/info-status-card.module.ts
@@ -17,7 +17,7 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [InfoStatusCardComponent],
-  exports: [InfoStatusCardComponent]
+  declarations: [ InfoStatusCardComponent ],
+  exports: [ InfoStatusCardComponent ]
 })
 export class InfoStatusCardModule {}

--- a/src/app/chart/chart-config.ts
+++ b/src/app/chart/chart-config.ts
@@ -1,0 +1,15 @@
+import { ChartConfigBase } from './chart-config-base';
+
+/**
+ * A base config containing properties for charts
+ *
+ * @deprecated Use ChartConfigBase
+ *
+ * import { ChartConfigBase } from patternfly-ng/chart;
+ */
+export abstract class ChartConfig extends ChartConfigBase {
+  constructor() {
+    super();
+    console.log('patternfly-ng: ChartConfig is deprecated; use ChartConfigBase');
+  }
+}

--- a/src/app/chart/chart.module.ts
+++ b/src/app/chart/chart.module.ts
@@ -5,19 +5,23 @@ import { NgModule } from '@angular/core';
 import { ChartBase } from './chart-base';
 import { ChartConfigBase } from './chart-config-base';
 import { ChartDefaults } from './chart-defaults';
-import { DonutComponent } from './donut-chart/basic-donut-chart/donut-chart.component';
-import { DonutConfig } from './donut-chart/basic-donut-chart/donut-chart-config';
+import { DonutComponent } from './donut-chart/donut.component';
+import { DonutConfig } from './donut-chart/donut-config';
 import { DonutChartModule } from './donut-chart/basic-donut-chart/donut-chart.module';
-import { SparklineComponent } from './sparkline-chart/sparkline-chart.component';
-import { SparklineConfig } from './sparkline-chart/sparkline-chart-config';
-import { SparklineData } from './sparkline-chart/sparkline-chart-data';
+import { SparklineComponent } from './sparkline-chart/sparkline.component';
+import { SparklineConfig } from './sparkline-chart/sparkline-config';
+import { SparklineData } from './sparkline-chart/sparkline-data';
 import { SparklineChartModule } from './sparkline-chart/sparkline-chart.module';
 import { WindowReference } from '../utilities/window.reference';
 
 export {
   ChartBase,
   ChartConfigBase,
-  ChartDefaults,
+  ChartDefaults
+};
+
+// @deprecated Use DonutChartComponent, SparklineChartConfig, and SparklineChartData
+export {
   DonutConfig,
   SparklineConfig,
   SparklineData
@@ -26,7 +30,12 @@ export {
 /**
  * A module containing objects associated with chart components
  *
- * @deprecated Use Use DonutChartModule or SparklineChartModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   DonutChartModule,
+ *   SparklineChartModule
+ * } from 'patterfnly/chart';
  */
 @NgModule({
   imports: [
@@ -35,8 +44,12 @@ export {
     FormsModule,
     SparklineChartModule
   ],
-  declarations: [DonutComponent, SparklineComponent],
-  exports: [DonutComponent, SparklineComponent],
-  providers: [ChartDefaults, WindowReference]
+  declarations: [ DonutComponent, SparklineComponent ],
+  exports: [ DonutComponent, SparklineComponent ],
+  providers: [ ChartDefaults, WindowReference ]
 })
-export class ChartModule {}
+export class ChartModule {
+  constructor() {
+    console.log('patternfly-ng: ChartModule is deprecated; use DonutChartModule or SparklineChartModule');
+  }
+}

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart-config.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart-config.ts
@@ -5,9 +5,3 @@ import { DonutChartBaseConfig } from '../donut-chart-base-config';
  */
 export class DonutChartConfig extends DonutChartBaseConfig {
 }
-
-/**
- * @deprecated Use DonutChartConfig
- */
-export class DonutConfig extends DonutChartConfig {
-}

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.spec.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.spec.ts
@@ -38,9 +38,9 @@ describe('Component: donut chart', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, FormsModule],
-      declarations: [DonutChartComponent],
-      providers: [ChartDefaults, WindowReference]
+      imports: [ BrowserAnimationsModule, FormsModule ],
+      declarations: [ DonutChartComponent ],
+      providers: [ ChartDefaults, WindowReference ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.ts
@@ -32,13 +32,3 @@ export class DonutChartComponent extends DonutChartBaseComponent {
     super(chartDefaults, windowRef);
   }
 }
-
-/**
- * @deprecated Use DonutChartComponent
- */
-@Component({
-  encapsulation: ViewEncapsulation.None,
-  selector: 'pfng-chart-donut',
-  templateUrl: './donut-chart.component.html'
-})
-export class DonutComponent extends DonutChartComponent {}

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
@@ -9,6 +9,7 @@ import { DonutChartComponent } from './donut-chart.component';
 import { WindowReference } from '../../../utilities/window.reference';
 
 export {
+  ChartDefaults,
   DonutChartConfig,
 };
 
@@ -17,8 +18,8 @@ export {
     CommonModule,
     FormsModule,
   ],
-  declarations: [DonutChartComponent],
-  exports: [DonutChartComponent],
-  providers: [ChartDefaults, WindowReference]
+  declarations: [ DonutChartComponent ],
+  exports: [ DonutChartComponent],
+  providers: [ ChartDefaults, WindowReference ]
 })
 export class DonutChartModule {}

--- a/src/app/chart/donut-chart/basic-donut-chart/example/donut-chart-example.module.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/example/donut-chart-example.module.ts
@@ -17,8 +17,8 @@ import { DonutChartExampleComponent } from './donut-chart-example.component';
     FormsModule,
     TabsModule.forRoot()
   ],
-  declarations: [DonutChartBasicExampleComponent, DonutChartDynamicExampleComponent, DonutChartExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ DonutChartBasicExampleComponent, DonutChartDynamicExampleComponent, DonutChartExampleComponent ],
+  providers: [ TabsetConfig ]
 })
 export class DonutChartExampleModule {
   constructor() { }

--- a/src/app/chart/donut-chart/basic-donut-chart/index.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/index.ts
@@ -1,6 +1,3 @@
 export { DonutChartComponent } from './donut-chart.component';
 export { DonutChartConfig } from './donut-chart-config';
 export { DonutChartModule } from './donut-chart.module';
-
-export { DonutComponent } from './donut-chart.component'; // @deprecated Use DonutChartComponent
-export { DonutConfig } from './donut-chart-config'; // @deprecated Use DonutChartConfig

--- a/src/app/chart/donut-chart/donut-config.ts
+++ b/src/app/chart/donut-chart/donut-config.ts
@@ -1,0 +1,16 @@
+import { DonutChartConfig } from './basic-donut-chart/donut-chart-config';
+import {UtilizationDonutChartConfig} from './utilization-donut-chart/utilization-donut-chart-config';
+
+/**
+ * A config containing properties for the sparkline chart
+ *
+ * @deprecated Use DonutChartConfig
+ *
+ * import { DonutChartConfig } from 'patternfly-ng/chart;
+ */
+export class DonutConfig extends DonutChartConfig {
+  constructor() {
+    super();
+    console.log('patternfly-ng: DonutConfig is deprecated; use DonutChartConfig or UtilizationDonutChartConfig');
+  }
+}

--- a/src/app/chart/donut-chart/donut.component.ts
+++ b/src/app/chart/donut-chart/donut.component.ts
@@ -1,0 +1,30 @@
+import {
+  Component,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { ChartDefaults } from '../chart-defaults';
+import { DonutChartComponent } from './basic-donut-chart/donut-chart.component';
+import { WindowReference } from '../../utilities/window.reference';
+
+/**
+ * Donut chart component.
+ *
+ * Note: In order to use charts, please include the following JavaScript file from patternfly. For example:
+ * <code>require('patternfly/dist/js/patternfly-settings');</code>
+ *
+ * @deprecated Use DonutChartComponent
+ *
+ * import { DonutChartComponent } from 'patternfly-ng/chart';
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-chart-donut',
+  templateUrl: './basic-donut-chart/donut-chart.component.html'
+})
+export class DonutComponent extends DonutChartComponent {
+  constructor(protected chartDefaults: ChartDefaults, protected windowRef: WindowReference) {
+    super(chartDefaults, windowRef);
+    console.log('patternfly-ng: DonutComponent is deprecated; use DonutChartComponent');
+  }
+}

--- a/src/app/chart/donut-chart/index.ts
+++ b/src/app/chart/donut-chart/index.ts
@@ -1,18 +1,8 @@
 export { DonutChartBaseComponent } from './donut-chart-base.component';
 export { DonutChartBaseConfig } from './donut-chart-base-config';
 
-// Basic Donut
-export {
-  DonutChartComponent,
-  DonutChartConfig,
-  DonutChartModule,
-  DonutComponent, // @deprecated Use DonutChartComponent
-  DonutConfig // @deprecated Use DonutChartConfig
-} from './basic-donut-chart/index';
+export { DonutComponent } from './donut.component'; // @deprecated Use DonutChartComponent
+export { DonutConfig } from './donut-config'; // @deprecated Use DonutChartConfig
 
-// Utilization Donut
-export {
-  UtilizationDonutChartComponent,
-  UtilizationDonutChartConfig,
-  UtilizationDonutChartModule
-} from './utilization-donut-chart/index';
+export * from './basic-donut-chart/index';
+export * from './utilization-donut-chart/index';

--- a/src/app/chart/donut-chart/utilization-donut-chart/example/utilization-donut-chart-example.module.ts
+++ b/src/app/chart/donut-chart/utilization-donut-chart/example/utilization-donut-chart-example.module.ts
@@ -4,22 +4,20 @@ import { NgModule } from '@angular/core';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { ChartModule } from '../../../chart.module';
 import { DemoComponentsModule } from '../../../../../demo/components/demo-components.module';
 import { UtilizationDonutChartExampleComponent } from './utilization-donut-chart-example.component';
 import { UtilizationDonutChartModule } from '../utilization-donut-chart.module';
 
 @NgModule({
   imports: [
-    ChartModule,
     CommonModule,
     DemoComponentsModule,
     FormsModule,
     UtilizationDonutChartModule,
     TabsModule.forRoot()
   ],
-  declarations: [UtilizationDonutChartExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ UtilizationDonutChartExampleComponent ],
+  providers: [ TabsetConfig ]
 })
 export class UtilizationDonutChartExampleModule {
   constructor() { }

--- a/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
+++ b/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
@@ -8,6 +8,7 @@ import { UtilizationDonutChartConfig } from './utilization-donut-chart-config';
 import { WindowReference } from '../../../utilities/window.reference';
 
 export {
+  ChartDefaults,
   UtilizationDonutChartConfig,
 };
 
@@ -16,8 +17,8 @@ export {
     CommonModule,
     FormsModule,
   ],
-  declarations: [UtilizationDonutChartComponent],
-  exports: [UtilizationDonutChartComponent],
-  providers: [ChartDefaults, WindowReference]
+  declarations: [ UtilizationDonutChartComponent ],
+  exports: [ UtilizationDonutChartComponent ],
+  providers: [ ChartDefaults, WindowReference ]
 })
 export class UtilizationDonutChartModule {}

--- a/src/app/chart/index.ts
+++ b/src/app/chart/index.ts
@@ -1,7 +1,9 @@
 export { ChartBase } from './chart-base';
 export { ChartConfigBase } from './chart-config-base';
 export { ChartDefaults } from './chart-defaults';
-export { ChartModule } from './chart.module'; // @deprecated Use DonutChartModule or SparklineChartModule
+
+export { ChartConfig } from './chart-config'; // @deprecated
+export { ChartModule } from './chart.module'; // @deprecated
 
 export * from './donut-chart/index';
 export * from './donut-chart/basic-donut-chart/index';

--- a/src/app/chart/sparkline-chart/example/sparkline-chart-example.module.ts
+++ b/src/app/chart/sparkline-chart/example/sparkline-chart-example.module.ts
@@ -16,8 +16,8 @@ import { SparklineChartModule } from '../sparkline-chart.module';
     SparklineChartModule,
     TabsModule.forRoot()
   ],
-  declarations: [SparklineChartExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ SparklineChartExampleComponent ],
+  providers: [ TabsetConfig]
 })
 export class SparklineChartExampleModule {
   constructor() {}

--- a/src/app/chart/sparkline-chart/index.ts
+++ b/src/app/chart/sparkline-chart/index.ts
@@ -3,6 +3,6 @@ export { SparklineChartConfig } from './sparkline-chart-config';
 export { SparklineChartData } from './sparkline-chart-data';
 export { SparklineChartModule } from './sparkline-chart.module';
 
-export { SparklineComponent } from './sparkline-chart.component'; // @deprecated Use SparklineChartComponent
-export { SparklineConfig } from './sparkline-chart-config'; // @deprecated Use SparklineChartConfig
-export { SparklineData } from './sparkline-chart-data'; // @deprecated Use SparklineChartData
+export { SparklineComponent } from './sparkline.component'; // @deprecated Use SparklineChartComponent
+export { SparklineConfig } from './sparkline-config'; // @deprecated Use SparklineChartConfig
+export { SparklineData } from './sparkline-data'; // @deprecated Use SparklineChartData

--- a/src/app/chart/sparkline-chart/sparkline-chart-config.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart-config.ts
@@ -48,8 +48,3 @@ export class SparklineChartConfig extends ChartConfigBase {
    */
   units?: string;
 }
-
-/**
- * @deprecated Use SparklineChartConfig
- */
-export class SparklineConfig extends SparklineChartConfig {}

--- a/src/app/chart/sparkline-chart/sparkline-chart-data.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart-data.ts
@@ -22,8 +22,3 @@ export abstract class SparklineChartData {
    */
   yData?: any[];
 }
-
-/**
- * @deprecated Use SparklineChartData
- */
-export abstract class SparklineData extends SparklineChartData {}

--- a/src/app/chart/sparkline-chart/sparkline-chart.component.spec.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.component.spec.ts
@@ -39,9 +39,9 @@ describe('Component: sparkline chart', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, FormsModule],
-      declarations: [SparklineChartComponent],
-      providers: [ChartDefaults]
+      imports: [ BrowserAnimationsModule, FormsModule ],
+      declarations: [ SparklineChartComponent ],
+      providers: [ ChartDefaults ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/chart/sparkline-chart/sparkline-chart.component.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.component.ts
@@ -49,7 +49,7 @@ export class SparklineChartComponent extends ChartBase implements DoCheck, OnIni
    * Default constructor
    * @param chartDefaults
    */
-  constructor(private chartDefaults: ChartDefaults) {
+  constructor(protected chartDefaults: ChartDefaults) {
     super();
   }
 
@@ -235,13 +235,3 @@ export class SparklineChartComponent extends ChartBase implements DoCheck, OnIni
       '</div>';
   }
 }
-
-/**
- * @deprecated Use SparklineChartComponent
- */
-@Component({
-  encapsulation: ViewEncapsulation.None,
-  selector: 'pfng-chart-sparkline',
-  templateUrl: './sparkline-chart.component.html'
-})
-export class SparklineComponent extends SparklineChartComponent {}

--- a/src/app/chart/sparkline-chart/sparkline-chart.module.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.module.ts
@@ -18,8 +18,8 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [SparklineChartComponent],
-  exports: [SparklineChartComponent],
-  providers: [ChartDefaults, WindowReference]
+  declarations: [ SparklineChartComponent ],
+  exports: [ SparklineChartComponent ],
+  providers: [ ChartDefaults, WindowReference ]
 })
 export class SparklineChartModule {}

--- a/src/app/chart/sparkline-chart/sparkline-config.ts
+++ b/src/app/chart/sparkline-chart/sparkline-config.ts
@@ -1,0 +1,16 @@
+import {SparklineChartConfig} from './sparkline-chart-config';
+import {ChartDefaults} from '../chart-defaults';
+
+/**
+ * A config containing properties for the sparkline chart
+ *
+ * @deprecated Use SparklineChartConfig
+ *
+ * import { SparklineChartConfig } from 'patternfly-ng/chart;
+ */
+export class SparklineConfig extends SparklineChartConfig {
+  constructor() {
+    super();
+    console.log('patternfly-ng: SparklineConfig is deprecated; use SparklineChartConfig');
+  }
+}

--- a/src/app/chart/sparkline-chart/sparkline-data.ts
+++ b/src/app/chart/sparkline-chart/sparkline-data.ts
@@ -1,0 +1,15 @@
+import {SparklineChartData} from './sparkline-chart-data';
+
+/**
+ * A base config containing properties for chart data
+ *
+ * @deprecated Use SparklineChartData
+ *
+ * import { SparklineChartData } from 'patternfly-ng/chart;
+ */
+export abstract class SparklineData extends SparklineChartData {
+  constructor() {
+    super();
+    console.log('patternfly-ng: SparklineData is deprecated; use SparklineChartData');
+  }
+}

--- a/src/app/chart/sparkline-chart/sparkline.component.ts
+++ b/src/app/chart/sparkline-chart/sparkline.component.ts
@@ -1,0 +1,29 @@
+import {
+  Component,
+  ViewEncapsulation
+} from '@angular/core';
+
+import { ChartDefaults } from '../chart-defaults';
+import { SparklineChartComponent } from './sparkline-chart.component';
+
+/**
+ * Sparkline chart component
+ *
+ * Note: In order to use charts, please include the following JavaScript file from patternfly. For example:
+ * <code>require('patternfly/dist/js/patternfly-settings');</code>
+ *
+ * @deprecated Use SparklineChartComponent
+ *
+ * import { SparklineChartComponent } from 'patternfly-ng/chart;
+ */
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'pfng-chart-sparkline',
+  templateUrl: './sparkline-chart.component.html'
+})
+export class SparklineComponent extends SparklineChartComponent {
+  constructor(protected chartDefaults: ChartDefaults) {
+    super(chartDefaults);
+    console.log('patternfly-ng: SparklineComponent is deprecated; use SparklineChartComponent');
+  }
+}

--- a/src/app/empty-state/empty-state.component.spec.ts
+++ b/src/app/empty-state/empty-state.component.spec.ts
@@ -51,8 +51,8 @@ describe('Empty state component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [EmptyStateComponent]
+      imports: [ FormsModule ],
+      declarations: [ EmptyStateComponent ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/empty-state/empty-state.module.ts
+++ b/src/app/empty-state/empty-state.module.ts
@@ -12,8 +12,8 @@ export {
  * A module containing objects associated with the empty state component
  */
 @NgModule({
-  imports: [CommonModule],
-  declarations: [EmptyStateComponent],
-  exports: [EmptyStateComponent]
+  imports: [ CommonModule ],
+  declarations: [ EmptyStateComponent ],
+  exports: [ EmptyStateComponent ]
 })
 export class EmptyStateModule {}

--- a/src/app/empty-state/example/empty-state-example.module.ts
+++ b/src/app/empty-state/example/empty-state-example.module.ts
@@ -7,14 +7,14 @@ import { EmptyStateModule } from '../empty-state.module';
 import { EmptyStateExampleComponent } from './empty-state-example.component';
 
 @NgModule({
-  declarations: [EmptyStateExampleComponent],
+  declarations: [ EmptyStateExampleComponent ],
   imports: [
     CommonModule,
     DemoComponentsModule,
     EmptyStateModule,
     TabsModule.forRoot()
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class EmptyStateExampleModule {
   constructor() {}

--- a/src/app/filter/example/filter-example.module.ts
+++ b/src/app/filter/example/filter-example.module.ts
@@ -27,7 +27,7 @@ import { FilterTypeAheadExampleComponent } from './filter-type-ahead-example.com
     FilterSaveExampleComponent,
     FilterTypeAheadExampleComponent
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class FilterExampleModule {
   constructor() {}

--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -20,7 +20,8 @@ import { FilterField } from './filter-field';
 import { FilterFieldsComponent } from './filter-fields.component';
 import { FilterResultsComponent } from './filter-results.component';
 import { FilterType } from './filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 describe('Filter component - ', () => {
   let comp: FilterComponent;
@@ -125,12 +126,13 @@ describe('Filter component - ', () => {
         BsDropdownModule.forRoot(),
         BrowserAnimationsModule,
         FormsModule,
-        PipeModule,
         PopoverModule.forRoot(),
-        TooltipModule.forRoot()
+        SearchHighlightPipeModule,
+        TooltipModule.forRoot(),
+        TruncatePipeModule
       ],
-      declarations: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],
-      providers: [BsDropdownConfig, TooltipConfig]
+      declarations: [ FilterComponent, FilterFieldsComponent, FilterResultsComponent ],
+      providers: [ BsDropdownConfig, TooltipConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/filter/filter.module.ts
+++ b/src/app/filter/filter.module.ts
@@ -15,7 +15,8 @@ import { FilterFieldsComponent } from './filter-fields.component';
 import { FilterResultsComponent } from './filter-results.component';
 import { FilterQuery } from './filter-query';
 import { FilterType } from './filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 export {
   Filter,
@@ -34,12 +35,13 @@ export {
     BsDropdownModule.forRoot(),
     CommonModule,
     FormsModule,
-    PipeModule,
     PopoverModule.forRoot(),
-    TooltipModule.forRoot()
+    SearchHighlightPipeModule,
+    TooltipModule.forRoot(),
+    TruncatePipeModule
   ],
-  declarations: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],
-  exports: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],
-  providers: [BsDropdownConfig, TooltipConfig]
+  declarations: [ FilterComponent, FilterFieldsComponent, FilterResultsComponent ],
+  exports: [ FilterComponent, FilterFieldsComponent, FilterResultsComponent ],
+  providers: [ BsDropdownConfig, TooltipConfig ]
 })
 export class FilterModule {}

--- a/src/app/list/basic-list/example/list-example.module.ts
+++ b/src/app/list/basic-list/example/list-example.module.ts
@@ -19,7 +19,7 @@ import { ListHeadingExampleComponent } from './list-heading-example.component';
 import { ListExampleComponent } from './list-example.component';
 import { ListPinExampleComponent } from './list-pin-example.component';
 import { NodesContentComponent } from './content/nodes-content.component';
-import { PipeModule } from '../../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../../pipe/sort-array';
 
 @NgModule({
   declarations: [
@@ -41,11 +41,11 @@ import { PipeModule } from '../../../pipe/pipe.module';
     DemoComponentsModule,
     FormsModule,
     ListModule,
-    PipeModule,
+    SortArrayPipeModule,
     TabsModule.forRoot(),
     TooltipModule.forRoot()
   ],
-  providers: [BsDropdownConfig, TabsetConfig, TooltipConfig]
+  providers: [ BsDropdownConfig, TabsetConfig, TooltipConfig ]
 })
 export class ListExampleModule {
   constructor() {}

--- a/src/app/list/basic-list/index.ts
+++ b/src/app/list/basic-list/index.ts
@@ -2,4 +2,3 @@ export { ListComponent } from './list.component';
 export { ListConfig } from './list-config';
 export { ListExpandToggleComponent } from './list-expand-toggle.component';
 export { ListModule } from './list.module';
-export { ListModule as BasicListModule  } from './list.module';

--- a/src/app/list/basic-list/list-config.ts
+++ b/src/app/list/basic-list/list-config.ts
@@ -1,9 +1,9 @@
-import { ListBaseConfig } from '../list-base-config';
+import { ListConfigBase } from '../list-config-base';
 
 /**
  * A config containing properties for list view
  */
-export class ListConfig extends ListBaseConfig {
+export class ListConfig extends ListConfigBase {
   /**
    * Set to true to hide the close button in the expansion area. Default is false
    */

--- a/src/app/list/basic-list/list.component.spec.ts
+++ b/src/app/list/basic-list/list.component.spec.ts
@@ -13,7 +13,7 @@ import { EmptyStateConfig } from '../../empty-state/empty-state-config';
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { ListComponent } from './list.component';
 import { ListConfig } from './list-config';
-import { PipeModule } from '../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../pipe/sort-array/sort-array.pipe.module';
 
 describe('List component - ', () => {
   let comp: ListComponent;
@@ -121,9 +121,9 @@ describe('List component - ', () => {
         BrowserAnimationsModule,
         EmptyStateModule,
         FormsModule,
-        PipeModule
+        SortArrayPipeModule
       ],
-      declarations: [ListComponent],
+      declarations: [ ListComponent ],
       providers: []
     })
       .compileComponents()

--- a/src/app/list/basic-list/list.module.ts
+++ b/src/app/list/basic-list/list.module.ts
@@ -5,12 +5,13 @@ import { NgModule } from '@angular/core';
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { ListComponent } from './list.component';
 import { ListConfig } from './list-config';
+import { ListEvent } from '../list-event';
 import { ListExpandToggleComponent } from './list-expand-toggle.component';
-import { PipeModule } from '../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../pipe/sort-array/sort-array.pipe.module';
 
 export {
   ListConfig,
-  ListExpandToggleComponent
+  ListEvent
 };
 
 /**
@@ -21,9 +22,9 @@ export {
     CommonModule,
     EmptyStateModule,
     FormsModule,
-    PipeModule
+    SortArrayPipeModule
   ],
-  declarations: [ListComponent, ListExpandToggleComponent],
-  exports: [ListComponent, ListExpandToggleComponent]
+  declarations: [ ListComponent, ListExpandToggleComponent ],
+  exports: [ ListComponent, ListExpandToggleComponent ]
 })
 export class ListModule {}

--- a/src/app/list/index.ts
+++ b/src/app/list/index.ts
@@ -1,5 +1,5 @@
 export { ListBase } from './list-base';
-export { ListBaseConfig } from './list-base-config';
+export { ListConfigBase } from './list-config-base';
 export { ListEvent } from './list-event';
 
 export * from './basic-list/index';

--- a/src/app/list/list-base.ts
+++ b/src/app/list/list-base.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 
 import { Action } from '../action/action';
-import { ListBaseConfig } from './list-base-config';
+import { ListConfigBase } from './list-config-base';
 import { ListEvent } from './list-event';
 
 /**
@@ -88,9 +88,9 @@ export abstract class ListBase {
   /**
    * Return component config
    *
-   * @returns {ListBaseConfig} The component config
+   * @returns {ListConfigBase} The component config
    */
-  protected abstract getConfig(): ListBaseConfig;
+  protected abstract getConfig(): ListConfigBase;
 
   // Accessors
 

--- a/src/app/list/list-config-base.ts
+++ b/src/app/list/list-config-base.ts
@@ -3,7 +3,7 @@ import { EmptyStateConfig } from '../empty-state/empty-state-config';
 /**
  * A config containing properties for tree list
  */
-export class ListBaseConfig {
+export class ListConfigBase {
   /**
    * Handle double clicking (item remains selected on a double click). Default is false
    */

--- a/src/app/list/list.module.ts
+++ b/src/app/list/list.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { ListBase } from './list-base';
-import { ListBaseConfig } from './list-base-config';
+import { ListConfigBase } from './list-config-base';
 import { ListEvent } from './list-event';
 import { ListComponent } from './basic-list/list.component';
 import { ListModule as BasicListModule } from './basic-list/list.module';
@@ -15,7 +15,7 @@ import { TreeListModule } from './tree-list/tree-list.module';
 
 export {
   ListBase,
-  ListBaseConfig,
+  ListConfigBase,
   ListConfig,
   ListEvent,
   TreeListConfig
@@ -24,7 +24,12 @@ export {
 /**
  * A module containing objects associated with list components
  *
- * @deprecated Use BasicListModule or TreeListModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   ListModule, // basic list only
+ *   TreeListModule
+ * } from 'patternfly-ng/list';
  */
 @NgModule({
   imports: [
@@ -33,6 +38,10 @@ export {
     FormsModule,
     TreeListModule
   ],
-  exports: [ListComponent, ListExpandToggleComponent, TreeListComponent]
+  exports: [ ListComponent, ListExpandToggleComponent, TreeListComponent ]
 })
-export class ListModule {}
+export class ListModule {
+  constructor() {
+    console.log('patternfly-ng: ListModule is deprecated; use TreeListModule and ListModule for basic list only');
+  }
+}

--- a/src/app/list/tree-list/example/tree-list-example.module.ts
+++ b/src/app/list/tree-list/example/tree-list-example.module.ts
@@ -27,7 +27,7 @@ import { TreeListModule } from '../tree-list.module';
     TreeListModule,
     TreeModule
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class TreeListExampleModule {
   constructor() {}

--- a/src/app/list/tree-list/tree-list-config.ts
+++ b/src/app/list/tree-list/tree-list-config.ts
@@ -1,9 +1,9 @@
-import { ListBaseConfig } from '../list-base-config';
+import { ListConfigBase } from '../list-config-base';
 
 /**
  * A config containing properties for tree list
  */
-export class TreeListConfig extends ListBaseConfig {
+export class TreeListConfig extends ListConfigBase {
   /**
    * Indent children by the given value in pixels
    */

--- a/src/app/list/tree-list/tree-list.component.spec.ts
+++ b/src/app/list/tree-list/tree-list.component.spec.ts
@@ -116,7 +116,7 @@ describe('Tree List component - ', () => {
         FormsModule,
         TreeModule
       ],
-      declarations: [TreeListComponent]
+      declarations: [ TreeListComponent ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/list/tree-list/tree-list.module.ts
+++ b/src/app/list/tree-list/tree-list.module.ts
@@ -2,12 +2,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { EmptyStateModule } from '../../empty-state/empty-state.module';
-import { TreeListComponent } from './tree-list.component';
-import { TreeListConfig } from './tree-list-config';
 import { TreeModule } from 'angular-tree-component';
 
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { ListEvent } from '../list-event';
+import { TreeListComponent } from './tree-list.component';
+import { TreeListConfig } from './tree-list-config';
+
 export {
+  ListEvent,
   TreeListConfig
 };
 
@@ -21,7 +24,7 @@ export {
     FormsModule,
     TreeModule
   ],
-  declarations: [TreeListComponent],
-  exports: [TreeListComponent]
+  declarations: [ TreeListComponent ],
+  exports: [ TreeListComponent ]
 })
 export class TreeListModule {}

--- a/src/app/modal/about-modal.component.spec.ts
+++ b/src/app/modal/about-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('AboutModal component - ', () => {
         FormsModule,
         ModalModule.forRoot()
       ],
-      declarations: [AboutModalComponent]
+      declarations: [ AboutModalComponent ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/modal/example/about-modal-example.module.ts
+++ b/src/app/modal/example/about-modal-example.module.ts
@@ -19,7 +19,7 @@ import { ModalModule } from '../modal.module';
     TabsModule.forRoot(),
     ModalModule
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class AboutModalExampleModule {
   constructor() { }

--- a/src/app/modal/modal.module.ts
+++ b/src/app/modal/modal.module.ts
@@ -12,8 +12,8 @@ export {
     imports: [
       CommonModule
     ],
-    declarations: [AboutModalComponent],
-    exports: [AboutModalComponent]
+    declarations: [ AboutModalComponent ],
+    exports: [ AboutModalComponent ]
 })
 
 export class ModalModule {}

--- a/src/app/navigation/application-launcher/application-launcher-config.ts
+++ b/src/app/navigation/application-launcher/application-launcher-config.ts
@@ -1,0 +1,6 @@
+import { NavigationConfigBase } from '../navigation-config-base';
+
+/**
+ * A config containing properties for application launcher items
+ */
+export class ApplicationLauncherConfig extends NavigationConfigBase {}

--- a/src/app/navigation/application-launcher/application-launcher.component.spec.ts
+++ b/src/app/navigation/application-launcher/application-launcher.component.spec.ts
@@ -12,12 +12,12 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap';
 
 import { ApplicationLauncherComponent } from './application-launcher.component';
-import { NavigationItemConfig } from '../navigation-item-config';
+import { ApplicationLauncherConfig } from './application-launcher-config';
 
 describe('Application Launcher componet', () => {
   let comp: ApplicationLauncherComponent;
   let fixture: ComponentFixture<ApplicationLauncherComponent>;
-  let navigationItems: NavigationItemConfig[];
+  let navigationItems: ApplicationLauncherConfig[];
 
   beforeEach(() => {
     navigationItems = [{
@@ -62,8 +62,8 @@ describe('Application Launcher componet', () => {
         FormsModule,
         TooltipModule.forRoot()
       ],
-      declarations: [ApplicationLauncherComponent],
-      providers: [BsDropdownConfig]
+      declarations: [ ApplicationLauncherComponent ],
+      providers: [ BsDropdownConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/navigation/application-launcher/application-launcher.component.ts
+++ b/src/app/navigation/application-launcher/application-launcher.component.ts
@@ -5,17 +5,16 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { NavigationItemConfig } from '../navigation-item-config';
+import { ApplicationLauncherConfig } from './application-launcher-config';
 
+/**
+ * Application launcher component
+ */
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'pfng-application-launcher',
   templateUrl: './application-launcher.component.html'
 })
-
-/**
- * Application launcher component
- */
 export class ApplicationLauncherComponent  implements OnInit {
   /**
    * Disable the application launcher button, default: false
@@ -25,7 +24,7 @@ export class ApplicationLauncherComponent  implements OnInit {
   /**
    * The navigation items used to build the menu
    */
-  @Input() items: NavigationItemConfig[];
+  @Input() items: ApplicationLauncherConfig[];
 
   /**
    *  Use a custom label for the launcher, default: Application Launcher

--- a/src/app/navigation/application-launcher/application-launcher.module.ts
+++ b/src/app/navigation/application-launcher/application-launcher.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { ApplicationLauncherConfig } from './application-launcher-config';
+import { ApplicationLauncherComponent } from './application-launcher.component';
+
+export {
+  ApplicationLauncherConfig
+};
+
+/**
+ * A module containing objects associated with the navigation components
+ */
+@NgModule({
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule
+  ],
+  declarations: [ ApplicationLauncherComponent ],
+  exports: [ ApplicationLauncherComponent ],
+  providers: [ BsDropdownConfig ]
+})
+export class ApplicationLauncherModule {}

--- a/src/app/navigation/application-launcher/example/application-launcher-example.component.ts
+++ b/src/app/navigation/application-launcher/example/application-launcher-example.component.ts
@@ -4,7 +4,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { NavigationItemConfig } from '../../navigation-item-config';
+import { ApplicationLauncherConfig } from '../application-launcher-config';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -13,7 +13,7 @@ import { NavigationItemConfig } from '../../navigation-item-config';
 })
 export class ApplicationLauncherExampleComponent  implements OnInit {
   disabled: boolean = false;
-  navigationItems: NavigationItemConfig[];
+  navigationItems: ApplicationLauncherConfig[];
   showIcons: boolean = true;
 
   ngOnInit(): void {

--- a/src/app/navigation/application-launcher/example/application-launcher-example.module.ts
+++ b/src/app/navigation/application-launcher/example/application-launcher-example.module.ts
@@ -4,23 +4,23 @@ import { NgModule } from '@angular/core';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { NavigationModule } from '../../navigation.module';
+import { ApplicationLauncherModule } from '../application-launcher.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { ApplicationLauncherExampleComponent } from './application-launcher-example.component';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   imports: [
+    ApplicationLauncherModule,
     CommonModule,
     DemoComponentsModule,
     FormsModule,
     RouterModule,
-    NavigationModule,
     TabsModule.forRoot()
   ],
-  declarations: [ApplicationLauncherExampleComponent],
-  exports: [ApplicationLauncherExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ ApplicationLauncherExampleComponent ],
+  exports: [ ApplicationLauncherExampleComponent ],
+  providers: [ TabsetConfig ]
 })
 export class ApplicationLauncherExampleModule {
   constructor() {}

--- a/src/app/navigation/application-launcher/index.ts
+++ b/src/app/navigation/application-launcher/index.ts
@@ -1,0 +1,3 @@
+export { ApplicationLauncherComponent } from './application-launcher.component';
+export { ApplicationLauncherConfig } from './application-launcher-config';
+export { ApplicationLauncherModule } from './application-launcher.module';

--- a/src/app/navigation/index.ts
+++ b/src/app/navigation/index.ts
@@ -1,4 +1,6 @@
-export { NavigationItemConfig } from './navigation-item-config';
-export { NavigationModule } from './navigation.module';
-export { VerticalNavigationComponent } from './vertical-navigation/vertical-navigation.component';
-export { ApplicationLauncherComponent } from './application-launcher/application-launcher.component';
+export { NavigationConfigBase } from './navigation-config-base';
+export { NavigationItemConfig } from './navigation-item-config'; // @deprecated
+export { NavigationModule } from './navigation.module'; // @deprecated
+
+export * from './application-launcher/index';
+export * from './vertical-navigation/index';

--- a/src/app/navigation/navigation-config-base.ts
+++ b/src/app/navigation/navigation-config-base.ts
@@ -1,0 +1,69 @@
+/**
+ * A config containing properties for navigation items
+ */
+export class NavigationConfigBase {
+  /**
+   * Title for the navigation item
+   */
+  title: string;
+
+  /**
+   * The icon class to use for icons displayed to the left of text
+   */
+  iconStyleClass?: string;
+
+  /**
+   * Link to navigate to
+   */
+  url?: string;
+
+  /**
+   * Badges to display information about the navigation item
+   */
+  badges?: any[];
+
+  /**
+   * Navigation children (used for secondary and tertiary navigation)
+   */
+  children?: NavigationConfigBase[];
+
+  /**
+   * Indicate if the item should be active on load
+   */
+  activeOnLoad?: boolean;
+
+  /**
+   * Track the active state of the navigation item
+   */
+  trackActiveState?: boolean;
+
+  /**
+   * Track the hover state of the navigation item
+   */
+  trackHoverState?: boolean;
+
+  /**
+   * Indicates if the child secondary menu is opened
+   */
+  secondaryCollapsed?: boolean;
+
+  /**
+   * Indicates if the child tertiary menu is opened
+   */
+  tertiaryCollapsed?: boolean;
+
+  /**
+   * Indicates if this is a mobile item
+   */
+  mobileItem?: boolean;
+
+  /**
+   * Internal variable used for hovering timeout
+   */
+  hoverTimeout?: any;
+
+  /**
+   * Internal variable used for blur timeout
+   */
+  blurTimeout?: any;
+}

--- a/src/app/navigation/navigation-item-config.ts
+++ b/src/app/navigation/navigation-item-config.ts
@@ -1,70 +1,15 @@
+import { NavigationConfigBase } from './navigation-config-base';
+import {VerticalNavigationConfig} from './vertical-navigation/vertical-navigation-config';
+
 /**
  * A config containing properties for navigation items
+ *
+ * @deprecated Use NavigationConfigBase
  */
-export class NavigationItemConfig {
-
-  /**
-   * Title for the navigation item
-   */
-  title: string;
-
-  /**
-   * The icon class to use for icons displayed to the left of text
-   */
-  iconStyleClass?: string;
-
-  /**
-   * Link to navigate to
-   */
-  url?: string;
-
-  /**
-   * Badges to display information about the navigation item
-   */
-  badges?: any[];
-
-  /**
-   * Navigation children (used for secondary and tertiary navigation)
-   */
-  children?: NavigationItemConfig[];
-
-  /**
-   * Indicate if the item should be active on load
-   */
-  activeOnLoad?: boolean;
-
-  /**
-   * Track the active state of the navigation item
-   */
-  trackActiveState?: boolean;
-
-  /**
-   * Track the hover state of the navigation item
-   */
-  trackHoverState?: boolean;
-
-  /**
-   * Indicates if the child secondary menu is opened
-   */
-  secondaryCollapsed?: boolean;
-
-  /**
-   * Indicates if the child tertiary menu is opened
-   */
-  tertiaryCollapsed?: boolean;
-
-  /**
-   * Indicates if this is a mobile item
-   */
-  mobileItem?: boolean;
-
-  /**
-   * Internal variable used for hovering timeout
-   */
-  hoverTimeout?: any;
-
-  /**
-   * Internal variable used for blur timeout
-   */
-  blurTimeout?: any;
+export class NavigationItemConfig extends NavigationConfigBase {
+  constructor() {
+    super();
+    console.log('patternfly-ng: NavigationItemConfig is deprecated; use NavigationConfigBase, ' +
+      'ApplicationLauncherConfig, or VerticalNavigationConfig');
+  }
 }

--- a/src/app/navigation/navigation.module.ts
+++ b/src/app/navigation/navigation.module.ts
@@ -4,10 +4,10 @@ import { NgModule } from '@angular/core';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
+import { ApplicationLauncherModule } from './application-launcher/application-launcher.module';
 import { NavigationItemConfig } from './navigation-item-config';
-import { VerticalNavigationComponent } from './vertical-navigation/vertical-navigation.component';
+import { VerticalNavigationModule } from './vertical-navigation/vertical-navigation.module';
 import { WindowReference } from '../utilities/window.reference';
-import { ApplicationLauncherComponent } from './application-launcher/application-launcher.component';
 
 export {
   NavigationItemConfig
@@ -15,15 +15,27 @@ export {
 
 /**
  * A module containing objects associated with the navigation components
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   ApplicationLauncherModule,
+ *   VerticalNavigationModule
+ * } from 'patternfly-ng/navigation;
  */
 @NgModule({
   imports: [
+    ApplicationLauncherModule,
     BsDropdownModule.forRoot(),
     CommonModule,
-    TooltipModule.forRoot()
+    TooltipModule.forRoot(),
+    VerticalNavigationModule
   ],
-  declarations: [ ApplicationLauncherComponent, VerticalNavigationComponent],
-  exports: [ ApplicationLauncherComponent, VerticalNavigationComponent],
-  providers: [BsDropdownConfig, TooltipConfig, WindowReference]
+  providers: [ BsDropdownConfig, TooltipConfig, WindowReference ]
 })
-export class NavigationModule {}
+export class NavigationModule {
+  constructor() {
+    console.log('patternfly-ng: NavigationModule is deprecated; use ApplicationLauncherModule ' +
+      'or VerticalNavigationModule');
+  }
+}

--- a/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.ts
+++ b/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.ts
@@ -4,7 +4,8 @@ import {
   OnInit, ViewEncapsulation
 } from '@angular/core';
 import { Router } from '@angular/router';
-import { NavigationItemConfig } from '../../navigation-item-config';
+
+import { VerticalNavigationConfig } from '../vertical-navigation-config';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -44,7 +45,7 @@ import { NavigationItemConfig } from '../../navigation-item-config';
 export class VerticalNavigationExampleComponent implements OnInit {
 
   showExample: boolean = false;
-  navigationItems: NavigationItemConfig[];
+  navigationItems: VerticalNavigationConfig[];
   actionText: string = '';
 
   constructor(private chRef: ChangeDetectorRef, private router: Router) {
@@ -276,11 +277,11 @@ export class VerticalNavigationExampleComponent implements OnInit {
     this.chRef.detectChanges();
   }
 
-  onItemClicked($event: NavigationItemConfig): void {
+  onItemClicked($event: VerticalNavigationConfig): void {
     this.actionText += 'Item Clicked: ' + $event.title + '\n';
   }
 
-  onNavigation($event: NavigationItemConfig): void {
+  onNavigation($event: VerticalNavigationConfig): void {
     this.actionText += 'Navigation event fired: ' + $event.title + '\n';
   }
 }

--- a/src/app/navigation/vertical-navigation/example/vertical-navigation-example.module.ts
+++ b/src/app/navigation/vertical-navigation/example/vertical-navigation-example.module.ts
@@ -1,28 +1,28 @@
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
-import { NavigationModule } from '../../navigation.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { VerticalNavigationExampleComponent } from './vertical-navigation-example.component';
-import { RouterModule } from '@angular/router';
+import { VerticalNavigationModule } from '../vertical-navigation.module';
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
     DemoComponentsModule,
     FormsModule,
     RouterModule,
-    NavigationModule,
     TabsModule.forRoot(),
-    BsDropdownModule.forRoot()
+    VerticalNavigationModule
   ],
-  declarations: [VerticalNavigationExampleComponent],
-  exports: [VerticalNavigationExampleComponent],
-  providers: [TabsetConfig, BsDropdownConfig]
+  declarations: [ VerticalNavigationExampleComponent ],
+  exports: [ VerticalNavigationExampleComponent ],
+  providers: [ TabsetConfig, BsDropdownConfig ]
 })
 export class VerticalNavigationExampleModule {
   constructor() {}

--- a/src/app/navigation/vertical-navigation/index.ts
+++ b/src/app/navigation/vertical-navigation/index.ts
@@ -1,0 +1,3 @@
+export { VerticalNavigationComponent } from './vertical-navigation.component';
+export { VerticalNavigationConfig } from './vertical-navigation-config';
+export { VerticalNavigationModule } from './vertical-navigation.module';

--- a/src/app/navigation/vertical-navigation/vertical-navigation-config.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation-config.ts
@@ -1,0 +1,6 @@
+import { NavigationConfigBase } from '../navigation-config-base';
+
+/**
+ * A config containing properties for vertical navigation items
+ */
+export class VerticalNavigationConfig extends NavigationConfigBase {}

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.spec.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.spec.ts
@@ -6,16 +6,17 @@ import {
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 
-import { NavigationItemConfig } from '../navigation-item-config';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TooltipModule } from 'ngx-bootstrap';
+
 import { VerticalNavigationComponent } from './vertical-navigation.component';
+import { VerticalNavigationConfig } from './vertical-navigation-config';
 import { WindowReference } from '../../utilities/window.reference';
 
 describe('Vertical Navigation component - ', () => {
   let comp: VerticalNavigationComponent;
   let fixture: ComponentFixture<VerticalNavigationComponent>;
-  let navigationItems: NavigationItemConfig[];
+  let navigationItems: VerticalNavigationConfig[];
   let navigateItem, clickItem;
 
   beforeEach(() => {
@@ -198,9 +199,9 @@ describe('Vertical Navigation component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, TooltipModule.forRoot(), RouterTestingModule],
-      declarations: [VerticalNavigationComponent],
-      providers: [WindowReference]
+      imports: [ FormsModule, TooltipModule.forRoot(), RouterTestingModule ],
+      declarations: [ VerticalNavigationComponent ],
+      providers: [ WindowReference ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
@@ -10,7 +10,8 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { NavigationItemConfig } from '../navigation-item-config';
+
+import { VerticalNavigationConfig } from './vertical-navigation-config';
 
 import { WindowReference } from '../../utilities/window.reference';
 
@@ -61,7 +62,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
   /**
    * The navigation items used to build the menu
    */
-  @Input() items: NavigationItemConfig[];
+  @Input() items: VerticalNavigationConfig[];
 
   /**
    * Sets an active flag on items when they are selected, default: false
@@ -361,7 +362,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * @param primary
    * @param secondary
    */
-  public handleSecondaryClick(primary: NavigationItemConfig, secondary: NavigationItemConfig): void {
+  public handleSecondaryClick(primary: VerticalNavigationConfig, secondary: VerticalNavigationConfig): void {
     if (this.inMobileState === true) {
       if (secondary.children && secondary.children.length > 0) {
         this.updateMobileMenu(primary, secondary);
@@ -380,8 +381,8 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * @param secondary
    * @param tertiary
    */
-  public handleTertiaryClick(primary: NavigationItemConfig, secondary: NavigationItemConfig,
-      tertiary: NavigationItemConfig): void {
+  public handleTertiaryClick(primary: VerticalNavigationConfig, secondary: VerticalNavigationConfig,
+      tertiary: VerticalNavigationConfig): void {
     if (this.inMobileState === true) {
       this.updateMobileMenu();
     }
@@ -392,7 +393,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    *  Show secondary nav bar on hover of primary nav items
    * @param item
    */
-  public handlePrimaryHover(item: NavigationItemConfig): void {
+  public handlePrimaryHover(item: VerticalNavigationConfig): void {
     if (item.children !== undefined && item.children.length > 0) {
       if (this.inMobileState !== true) {
         if (item.blurTimeout !== undefined) {
@@ -413,7 +414,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * Hides menus on blur
    * @param item
    */
-  public handlePrimaryBlur(item: NavigationItemConfig): void {
+  public handlePrimaryBlur(item: VerticalNavigationConfig): void {
     if (item.children !== undefined && item.children.length > 0) {
       if (item.hoverTimeout !== undefined) {
         clearTimeout(item.hoverTimeout);
@@ -455,7 +456,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * Hides menus on blur
    * @param item
    */
-  public handleSecondaryBlur(item: NavigationItemConfig): void {
+  public handleSecondaryBlur(item: VerticalNavigationConfig): void {
     if (item.children !== undefined && item.children.length > 0) {
       if (item.hoverTimeout !== undefined) {
         clearTimeout(item.hoverTimeout);
@@ -476,7 +477,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * Collapse secondary navigation
    * @param item
    */
-  public collapseSecondaryNav(item: NavigationItemConfig): void {
+  public collapseSecondaryNav(item: VerticalNavigationConfig): void {
     if (this.inMobileState === true) {
       this.updateMobileMenu();
     } else {
@@ -494,7 +495,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
    * Collapse tertiary navigation
    * @param item
    */
-  public collapseTertiaryNav(item: NavigationItemConfig): void {
+  public collapseTertiaryNav(item: VerticalNavigationConfig): void {
     if (this.inMobileState === true) {
       this.items.forEach((primaryItem) => {
         if (primaryItem.children !== undefined) {
@@ -544,7 +545,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     }
   }
 
-  private updateMobileMenu(selected?: NavigationItemConfig, secondaryItem?: NavigationItemConfig): void {
+  private updateMobileMenu(selected?: VerticalNavigationConfig, secondaryItem?: VerticalNavigationConfig): void {
     this.items.forEach((item) => {
       item.mobileItem = false;
       if (item.children !== undefined) {
@@ -642,7 +643,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     }, 500);
   }
 
-  private setParentActive(item: NavigationItemConfig) {
+  private setParentActive(item: VerticalNavigationConfig) {
     this.items.forEach((topLevel) => {
       if (topLevel.children !== undefined) {
         topLevel.children.forEach((secondLevel) => {
@@ -662,7 +663,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getFirstNavigateChild(item: NavigationItemConfig): NavigationItemConfig {
+  private getFirstNavigateChild(item: VerticalNavigationConfig): VerticalNavigationConfig {
     let firstChild;
     if (item.children === undefined || item.children.length < 1) {
       firstChild = item;
@@ -695,7 +696,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     }
   }
 
-  private navigateToItem(item: NavigationItemConfig): void {
+  private navigateToItem(item: VerticalNavigationConfig): void {
     let navItem = this.getFirstNavigateChild(item);
     let navTo;
     if (navItem) {
@@ -746,7 +747,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     return hover;
   }
 
-  private updateSecondaryCollapsedState(setCollapsed: boolean, collapsedItem?: NavigationItemConfig) {
+  private updateSecondaryCollapsedState(setCollapsed: boolean, collapsedItem?: VerticalNavigationConfig) {
     if (collapsedItem !== undefined) {
       collapsedItem.secondaryCollapsed = setCollapsed;
     }
@@ -771,7 +772,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     }
   }
 
-  private updateTertiaryCollapsedState(setCollapsed: boolean, collapsedItem?: NavigationItemConfig): void {
+  private updateTertiaryCollapsedState(setCollapsed: boolean, collapsedItem?: VerticalNavigationConfig): void {
     if (collapsedItem !== undefined) {
       collapsedItem.tertiaryCollapsed = setCollapsed;
     }

--- a/src/app/navigation/vertical-navigation/vertical-navigation.module.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.module.ts
@@ -1,0 +1,26 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+
+import { VerticalNavigationConfig } from './vertical-navigation-config';
+import { VerticalNavigationComponent } from './vertical-navigation.component';
+import { WindowReference } from '../../utilities/window.reference';
+
+export {
+  VerticalNavigationConfig
+};
+
+/**
+ * A module containing objects associated with the navigation components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    TooltipModule.forRoot()
+  ],
+  declarations: [ VerticalNavigationComponent ],
+  exports: [ VerticalNavigationComponent ],
+  providers: [ TooltipConfig, WindowReference ]
+})
+export class VerticalNavigationModule {}

--- a/src/app/notification/index.ts
+++ b/src/app/notification/index.ts
@@ -1,10 +1,11 @@
-export { InlineNotificationComponent } from './inline-notification/inline-notification.component';
 export { Notification } from './notification';
-export { NotificationDrawerComponent  } from './notification-drawer/notification-drawer.component';
 export { NotificationEvent } from './notification-event';
 export { NotificaitonGroup } from './notification-group';
-export { NotificationModule } from './notification.module';
+export { NotificationModule } from './notification.module'; // @deprecated
 export { NotificationType } from './notification-type';
-export { NotificationService } from './notification-service/notification.service';
-export { ToastNotificationComponent } from './toast-notification/toast-notification.component';
-export { ToastNotificationListComponent } from './toast-notification-list/toast-notification-list.component';
+
+export * from './inline-notification/index';
+export * from './notification-drawer/index';
+export * from './notification-service/index';
+export * from './toast-notification/index';
+export * from './toast-notification-list/index';

--- a/src/app/notification/inline-notification/example/inline-notification-example.module.ts
+++ b/src/app/notification/inline-notification/example/inline-notification-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { InlineNotificationExampleComponent } from './inline-notification-example.component';
+import { InlineNotificationModule } from '../inline-notification.module';
 
 @NgModule({
   declarations: [
@@ -18,7 +18,7 @@ import { InlineNotificationExampleComponent } from './inline-notification-exampl
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
+    InlineNotificationModule,
     TabsModule.forRoot()
   ],
   providers: [

--- a/src/app/notification/inline-notification/index.ts
+++ b/src/app/notification/inline-notification/index.ts
@@ -1,0 +1,2 @@
+export { InlineNotificationComponent } from './inline-notification.component';
+export { InlineNotificationModule } from './inline-notification.module';

--- a/src/app/notification/inline-notification/inline-notification.component.spec.ts
+++ b/src/app/notification/inline-notification/inline-notification.component.spec.ts
@@ -15,8 +15,8 @@ describe('Inline notification component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [InlineNotificationComponent],
+      imports: [ FormsModule ],
+      declarations: [ InlineNotificationComponent ],
       providers: []
     })
       .compileComponents()

--- a/src/app/notification/inline-notification/inline-notification.component.ts
+++ b/src/app/notification/inline-notification/inline-notification.component.ts
@@ -48,7 +48,6 @@ export class InlineNotificationComponent {
    */
   @Output('hiddenChange') hiddenChange = new EventEmitter<boolean>();
 
-
   /**
    * The default constructor
    */
@@ -62,5 +61,4 @@ export class InlineNotificationComponent {
     this.hidden = true;
     this.hiddenChange.emit(this.hidden);
   }
-
 }

--- a/src/app/notification/inline-notification/inline-notification.module.ts
+++ b/src/app/notification/inline-notification/inline-notification.module.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { InlineNotificationComponent } from './inline-notification.component';
+import { NotificationType } from '../notification-type';
+
+export {
+  NotificationType
+};
+
+/**
+ * A module containing objects associated with inline notifications
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    InlineNotificationComponent
+  ],
+  exports: [
+    InlineNotificationComponent
+  ]
+})
+export class InlineNotificationModule {}

--- a/src/app/notification/notification-drawer/example/notification-drawer-example.module.ts
+++ b/src/app/notification/notification-drawer/example/notification-drawer-example.module.ts
@@ -4,8 +4,8 @@ import { NgModule } from '@angular/core';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { NotificationModule } from '../../notification.module';
 import { NotificationDrawerExampleComponent } from './notification-drawer-example.component';
+import { NotificationDrawerModule } from '../notification-drawer.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { ActionModule } from '../../../action/action.module';
 
@@ -15,7 +15,7 @@ import { ActionModule } from '../../../action/action.module';
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
+    NotificationDrawerModule,
     TabsModule.forRoot()
   ],
   declarations: [ NotificationDrawerExampleComponent ],

--- a/src/app/notification/notification-drawer/index.ts
+++ b/src/app/notification/notification-drawer/index.ts
@@ -1,0 +1,2 @@
+export { NotificationDrawerComponent } from './notification-drawer.component';
+export { NotificationDrawerModule } from './notification-drawer.module';

--- a/src/app/notification/notification-drawer/notification-drawer.component.spec.ts
+++ b/src/app/notification/notification-drawer/notification-drawer.component.spec.ts
@@ -219,8 +219,8 @@ describe('notification drawer component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule,  EmptyStateModule, ActionModule],
-      declarations: [NotificationDrawerComponent],
+      imports: [ FormsModule,  EmptyStateModule, ActionModule ],
+      declarations: [ NotificationDrawerComponent ],
       providers: []
     })
       .compileComponents()

--- a/src/app/notification/notification-drawer/notification-drawer.module.ts
+++ b/src/app/notification/notification-drawer/notification-drawer.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { NotificationDrawerComponent } from './notification-drawer.component';
+import { NotificaitonGroup } from '../notification-group';
+
+export {
+  NotificaitonGroup
+};
+
+/**
+ * A module containing objects associated with the notification drawer
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    EmptyStateModule,
+    FormsModule
+  ],
+  declarations: [
+    NotificationDrawerComponent
+  ],
+  exports: [
+    NotificationDrawerComponent
+  ]
+})
+export class NotificationDrawerModule {}

--- a/src/app/notification/notification-service/example/notification-service-example.module.ts
+++ b/src/app/notification/notification-service/example/notification-service-example.module.ts
@@ -6,11 +6,12 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { NotificationService } from '../notification.service';
+import { NotificationServiceModule } from '../notification.service.module';
 import { NotificationServiceExampleComponent } from './notification-service-example.component';
 import { NotificationServiceBasicExampleComponent } from './notification-service-basic-example.component';
 import { NotificationServiceObserverExampleComponent } from './notification-service-observer-example.component';
+import { ToastNotificationListModule } from '../../toast-notification-list';
 
 @NgModule({
   declarations: [
@@ -23,8 +24,9 @@ import { NotificationServiceObserverExampleComponent } from './notification-serv
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    NotificationServiceModule,
+    TabsModule.forRoot(),
+    ToastNotificationListModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/notification-service/index.ts
+++ b/src/app/notification/notification-service/index.ts
@@ -1,0 +1,2 @@
+export { NotificationService } from './notification.service';
+export { NotificationServiceModule } from './notification.service.module';

--- a/src/app/notification/notification-service/notification.service.module.ts
+++ b/src/app/notification/notification-service/notification.service.module.ts
@@ -1,0 +1,26 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { Notification } from '../notification';
+import { NotificationType } from '../notification-type';
+import { NotificationService } from './notification.service';
+
+export {
+  Notification,
+  NotificationType
+};
+
+/**
+ * A module containing objects associated with the notification service
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  providers: [
+    NotificationService
+  ]
+})
+export class NotificationServiceModule {}

--- a/src/app/notification/notification.module.ts
+++ b/src/app/notification/notification.module.ts
@@ -1,16 +1,18 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { EmptyStateModule } from '../empty-state/empty-state.module';
+import { InlineNotificationComponent } from './inline-notification/inline-notification.component';
+import { NotificationDrawerComponent } from './notification-drawer/notification-drawer.component';
 import { NotificaitonGroup } from './notification-group';
 import { NotificationEvent } from './notification-event';
 import { NotificationType } from './notification-type';
 import { NotificationService } from './notification-service/notification.service';
 import { ToastNotificationComponent } from './toast-notification/toast-notification.component';
 import { ToastNotificationListComponent } from './toast-notification-list/toast-notification-list.component';
-import { InlineNotificationComponent } from './inline-notification/inline-notification.component';
-import { NotificationDrawerComponent } from './notification-drawer/notification-drawer.component';
-import { EmptyStateModule } from '../empty-state/empty-state.module';
 
 export {
   NotificationEvent,
@@ -20,13 +22,43 @@ export {
 
 /**
  * A module containing objects associated with notification components
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   InlineNotificationModule,
+ *   NotificationDrawerModule,
+ *   ToastNotificationModule,
+ *   ToastNotificationListModule
+ * } from 'patternfly-ng/list';
  */
 @NgModule({
-  imports: [BsDropdownModule.forRoot(), CommonModule, EmptyStateModule],
-  declarations: [ToastNotificationComponent, ToastNotificationListComponent, InlineNotificationComponent, 
-    NotificationDrawerComponent],
-  exports: [ToastNotificationComponent, ToastNotificationListComponent, InlineNotificationComponent, 
-    NotificationDrawerComponent],
-  providers: [BsDropdownConfig, NotificationService]
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    EmptyStateModule,
+    FormsModule
+  ],
+  declarations: [
+    InlineNotificationComponent,
+    NotificationDrawerComponent,
+    ToastNotificationComponent,
+    ToastNotificationListComponent
+  ],
+  exports: [
+    InlineNotificationComponent,
+    NotificationDrawerComponent,
+    ToastNotificationComponent,
+    ToastNotificationListComponent
+  ],
+  providers: [
+    BsDropdownConfig,
+    NotificationService
+  ]
 })
-export class NotificationModule {}
+export class NotificationModule {
+  constructor() {
+    console.log('patternfly-ng: NotificationModule is deprecated; use InlineNotificationModule, ' +
+      'NotificationDrawerModule, ToastNotificationModule, or ToastNotificationListModule');
+  }
+}

--- a/src/app/notification/toast-notification-list/example/toast-notification-list-example.module.ts
+++ b/src/app/notification/toast-notification-list/example/toast-notification-list-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { ToastNotificationListExampleComponent } from './toast-notification-list-example.component';
+import { ToastNotificationListModule } from '../toast-notification-list.module';
 
 @NgModule({
   declarations: [
@@ -18,8 +18,8 @@ import { ToastNotificationListExampleComponent } from './toast-notification-list
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    ToastNotificationListModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/toast-notification-list/index.ts
+++ b/src/app/notification/toast-notification-list/index.ts
@@ -1,0 +1,2 @@
+export { ToastNotificationListComponent } from './toast-notification-list.component';
+export { ToastNotificationListModule } from './toast-notification-list.module';

--- a/src/app/notification/toast-notification-list/toast-notification-list.module.ts
+++ b/src/app/notification/toast-notification-list/toast-notification-list.module.ts
@@ -1,0 +1,31 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { Notification } from '../notification';
+import { NotificationEvent } from '../notification-event';
+import { ToastNotificationListComponent } from './toast-notification-list.component';
+import { ToastNotificationModule } from '../toast-notification';
+
+export {
+  Notification,
+  NotificationEvent
+};
+
+/**
+ * A module containing objects associated with toast notification lists
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ToastNotificationModule
+  ],
+  declarations: [
+    ToastNotificationListComponent
+  ],
+  exports: [
+    ToastNotificationListComponent
+  ]
+})
+export class ToastNotificationListModule {}

--- a/src/app/notification/toast-notification/example/toast-notification-example.module.ts
+++ b/src/app/notification/toast-notification/example/toast-notification-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { ToastNotificationExampleComponent } from './toast-notification-example.component';
+import { ToastNotificationModule } from '../toast-notification.module';
 
 @NgModule({
   declarations: [
@@ -18,8 +18,8 @@ import { ToastNotificationExampleComponent } from './toast-notification-example.
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    ToastNotificationModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/toast-notification/index.ts
+++ b/src/app/notification/toast-notification/index.ts
@@ -1,0 +1,2 @@
+export { ToastNotificationComponent } from './toast-notification.component';
+export { ToastNotificationModule } from './toast-notification.module';

--- a/src/app/notification/toast-notification/toast-notification.module.ts
+++ b/src/app/notification/toast-notification/toast-notification.module.ts
@@ -1,0 +1,35 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { Notification } from '../notification';
+import { NotificationEvent } from '../notification-event';
+import { ToastNotificationComponent } from './toast-notification.component';
+
+export {
+  Notification,
+  NotificationEvent
+};
+
+/**
+ * A module containing objects associated with toast notifications
+ */
+@NgModule({
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    ToastNotificationComponent
+  ],
+  exports: [
+    ToastNotificationComponent
+  ],
+  providers: [
+    BsDropdownConfig
+  ]
+})
+export class ToastNotificationModule {}

--- a/src/app/pagination/example/pagination-example.module.ts
+++ b/src/app/pagination/example/pagination-example.module.ts
@@ -7,7 +7,7 @@ import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { ActionModule } from '../../action/action.module';
 import { DemoComponentsModule } from '../../../demo/components/demo-components.module';
-import { ListModule } from '../../list/list.module';
+import { ListModule } from '../../list/basic-list/list.module';
 import { PaginationModule } from '../pagination.module';
 import { PaginationExampleComponent } from './pagination-example.component';
 import { PaginationBasicExampleComponent } from './pagination-basic-example.component';
@@ -28,7 +28,7 @@ import { PaginationListExampleComponent } from './pagination-list-example.compon
     ListModule,
     TabsModule.forRoot(),
   ],
-  providers: [BsDropdownConfig, TabsetConfig]
+  providers: [ BsDropdownConfig, TabsetConfig ]
 })
 export class PaginationExampleModule {
   constructor() {}

--- a/src/app/pagination/pagination.component.spec.ts
+++ b/src/app/pagination/pagination.component.spec.ts
@@ -26,8 +26,8 @@ describe('Pagination component - ', () => {
       imports: [
         FormsModule,
         BsDropdownModule.forRoot()],
-      declarations: [PaginationComponent],
-      providers: [BsDropdownConfig]
+      declarations: [ PaginationComponent ],
+      providers: [ BsDropdownConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/pagination/pagination.module.ts
+++ b/src/app/pagination/pagination.module.ts
@@ -17,11 +17,12 @@ export {
  * A module containing objects associated with notification components
  */
 @NgModule({
-  imports: [BsDropdownModule.forRoot(),
+  imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
     FormsModule],
-  declarations: [PaginationComponent],
-  exports: [PaginationComponent],
-  providers: [BsDropdownConfig]
+  declarations: [ PaginationComponent ],
+  exports: [ PaginationComponent ],
+  providers: [ BsDropdownConfig ]
 })
 export class PaginationModule {}

--- a/src/app/patternfly-ng.module.ts
+++ b/src/app/patternfly-ng.module.ts
@@ -4,15 +4,15 @@ import { FormsModule } from '@angular/forms';
 import {
   ActionModule,
   CardModule,
-  ChartModule,
+  ChartModule, // @deprecated
   EmptyStateModule,
   FilterModule,
   ListModule,
   ModalModule,
-  NavigationModule,
-  NotificationModule,
+  NavigationModule, // @deprecated
+  NotificationServiceModule,
   PaginationModule,
-  PipeModule,
+  PipeModule, // @deprecated
   RemainingCharsCountModule,
   SampleModule,
   SortModule,
@@ -31,16 +31,16 @@ import {
   exports: [
     ActionModule,
     CardModule,
-    ChartModule,
+    ChartModule, // @deprecated
     EmptyStateModule,
     FilterModule,
     ListModule,
     ModalModule,
-    NavigationModule,
-    NotificationModule,
+    NavigationModule, // @deprecated
+    NotificationServiceModule,
     PaginationModule,
     RemainingCharsCountModule,
-    PipeModule,
+    PipeModule, // @deprecated
     SampleModule,
     SortModule,
     TableModule,

--- a/src/app/pipe/index.ts
+++ b/src/app/pipe/index.ts
@@ -1,4 +1,5 @@
+export * from './search-highlight/index';
+export * from './sort-array/index';
+export * from './truncate/index';
+
 export { PipeModule } from './pipe.module';
-export { SearchHighlightPipe } from './search-highlight/search-highlight.pipe';
-export { SortArrayPipe } from './sort-array/sort-array.pipe';
-export { TruncatePipe } from './truncate/truncate.pipe';

--- a/src/app/pipe/pipe.module.ts
+++ b/src/app/pipe/pipe.module.ts
@@ -1,21 +1,39 @@
 import { NgModule } from '@angular/core';
+
+import { SearchHighlightPipeModule } from './search-highlight/search-highlight.pipe.module';
 import { SearchHighlightPipe } from './search-highlight/search-highlight.pipe';
+import { SortArrayPipeModule } from './sort-array/sort-array.pipe.module';
 import { SortArrayPipe } from './sort-array/sort-array.pipe';
+import { TruncatePipeModule } from './truncate/truncate.pipe.module';
 import { TruncatePipe } from './truncate/truncate.pipe';
+
+export {
+  SearchHighlightPipe,
+  SortArrayPipe,
+  TruncatePipe
+};
 
 /**
  * A module containing objects associated with pipes
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   SearchHighlightModule,
+ *   SortArrayModule,
+ *   TruncateModule
+ * } from 'patternfly-ng/pipe';
  */
 @NgModule({
-  declarations: [
-    SearchHighlightPipe,
-    SortArrayPipe,
-    TruncatePipe
-  ],
-  exports: [
-    SearchHighlightPipe,
-    SortArrayPipe,
-    TruncatePipe
+  imports: [
+    SearchHighlightPipeModule,
+    SortArrayPipeModule,
+    TruncatePipeModule
   ]
 })
-export class PipeModule { }
+export class PipeModule {
+  constructor() {
+    console.log('patternfly-ng: PipeModule is deprecated; use SearchHighlightModule, ' +
+      'SortArrayModule, or TruncateModule');
+  }
+}

--- a/src/app/pipe/search-highlight/example/search-highlight-example.module.ts
+++ b/src/app/pipe/search-highlight/example/search-highlight-example.module.ts
@@ -4,19 +4,19 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { SearchHighlightExampleComponent } from './search-highlight-example.component';
+import { SearchHighlightPipeModule } from '../search-highlight.pipe.module';
 
 @NgModule({
-  declarations: [SearchHighlightExampleComponent],
+  declarations: [ SearchHighlightExampleComponent ],
   imports: [
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
+    SearchHighlightPipeModule,
     TabsModule.forRoot(),
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class SearchHighlightExampleModule {
   constructor() {}

--- a/src/app/pipe/search-highlight/index.ts
+++ b/src/app/pipe/search-highlight/index.ts
@@ -1,0 +1,2 @@
+export { SearchHighlightPipeModule } from './search-highlight.pipe.module';
+export { SearchHighlightPipe } from './search-highlight.pipe';

--- a/src/app/pipe/search-highlight/search-highlight.pipe.module.ts
+++ b/src/app/pipe/search-highlight/search-highlight.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { SearchHighlightPipe } from './search-highlight.pipe';
+
+/**
+ * A module containing objects associated with the search highlight pipe
+ */
+@NgModule({
+  declarations: [
+    SearchHighlightPipe
+  ],
+  exports: [
+    SearchHighlightPipe
+  ]
+})
+export class SearchHighlightPipeModule { }

--- a/src/app/pipe/sort-array/example/sort-array-example.module.ts
+++ b/src/app/pipe/sort-array/example/sort-array-example.module.ts
@@ -4,8 +4,8 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { SortArrayExampleComponent } from './sort-array-example.component';
+import { SortArrayPipeModule } from '../sort-array.pipe.module';
 
 @NgModule({
   declarations: [ SortArrayExampleComponent ],
@@ -13,7 +13,7 @@ import { SortArrayExampleComponent } from './sort-array-example.component';
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
+    SortArrayPipeModule,
     TabsModule.forRoot()
   ],
   providers: [ TabsetConfig ]

--- a/src/app/pipe/sort-array/index.ts
+++ b/src/app/pipe/sort-array/index.ts
@@ -1,0 +1,2 @@
+export { SortArrayPipeModule } from './sort-array.pipe.module';
+export { SortArrayPipe } from './sort-array.pipe';

--- a/src/app/pipe/sort-array/sort-array.pipe.module.ts
+++ b/src/app/pipe/sort-array/sort-array.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { SortArrayPipe } from './sort-array.pipe';
+
+/**
+ * A module containing objects associated with the sort array pipe
+ */
+@NgModule({
+  declarations: [
+    SortArrayPipe
+  ],
+  exports: [
+    SortArrayPipe
+  ]
+})
+export class SortArrayPipeModule { }

--- a/src/app/pipe/truncate/example/truncate-example.module.ts
+++ b/src/app/pipe/truncate/example/truncate-example.module.ts
@@ -4,8 +4,8 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { TruncateExampleComponent } from './truncate-example.component';
+import { TruncatePipeModule } from '../truncate.pipe.module';
 
 @NgModule({
   declarations: [ TruncateExampleComponent ],
@@ -13,8 +13,8 @@ import { TruncateExampleComponent } from './truncate-example.component';
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    TruncatePipeModule
   ],
   providers: [ TabsetConfig ]
 })

--- a/src/app/pipe/truncate/index.ts
+++ b/src/app/pipe/truncate/index.ts
@@ -1,0 +1,2 @@
+export { TruncatePipeModule } from './truncate.pipe.module';
+export { TruncatePipe } from './truncate.pipe';

--- a/src/app/pipe/truncate/truncate.pipe.module.ts
+++ b/src/app/pipe/truncate/truncate.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { TruncatePipe } from './truncate.pipe';
+
+/**
+ * A module containing objects associated with the truncate pipe
+ */
+@NgModule({
+  declarations: [
+    TruncatePipe
+  ],
+  exports: [
+    TruncatePipe
+  ]
+})
+export class TruncatePipeModule { }

--- a/src/app/remaining-chars-count/example/remaining-chars-count-example.module.ts
+++ b/src/app/remaining-chars-count/example/remaining-chars-count-example.module.ts
@@ -7,14 +7,14 @@ import { RemainingCharsCountModule } from '../remaining-chars-count.module';
 import { RemainingCharsCountExampleComponent } from './remaining-chars-count-example.component';
 
 @NgModule({
-  declarations: [RemainingCharsCountExampleComponent],
+  declarations: [ RemainingCharsCountExampleComponent ],
   imports: [
     CommonModule,
     DemoComponentsModule,
     RemainingCharsCountModule,
     TabsModule.forRoot(),
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class RemainingCharsCountExampleModule {
   constructor() {}

--- a/src/app/remaining-chars-count/remaining-chars-count.module.ts
+++ b/src/app/remaining-chars-count/remaining-chars-count.module.ts
@@ -8,8 +8,8 @@ import { RemainingCharsCountDirective } from './remaining-chars-count.directive'
  * A module containing objects associated with the remaining characters directive
  */
 @NgModule({
-  imports: [CommonModule, FormsModule],
-  declarations: [RemainingCharsCountDirective],
-  exports: [RemainingCharsCountDirective]
+  imports: [ CommonModule, FormsModule ],
+  declarations: [ RemainingCharsCountDirective ],
+  exports: [ RemainingCharsCountDirective ]
 })
 export class RemainingCharsCountModule {}

--- a/src/app/sample/example/sample-example.module.ts
+++ b/src/app/sample/example/sample-example.module.ts
@@ -15,9 +15,9 @@ import { SampleExampleComponent } from './sample-example.component';
     SampleModule,
     TabsModule.forRoot()
   ],
-  declarations: [SampleExampleComponent],
-  exports: [SampleExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ SampleExampleComponent ],
+  exports: [ SampleExampleComponent ],
+  providers: [ TabsetConfig ]
 })
 export class SampleExampleModule {
   constructor() {}

--- a/src/app/sample/sample.component.spec.ts
+++ b/src/app/sample/sample.component.spec.ts
@@ -14,8 +14,8 @@ describe('Sample component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [SampleComponent],
+      imports: [ FormsModule ],
+      declarations: [ SampleComponent ],
       providers: []
     })
       .compileComponents()

--- a/src/app/sample/sample.module.ts
+++ b/src/app/sample/sample.module.ts
@@ -7,8 +7,8 @@ import { SampleComponent } from './sample.component';
  * A module containing objects associated with the sample component
  */
 @NgModule({
-  imports: [CommonModule],
-  declarations: [SampleComponent],
-  exports: [SampleComponent]
+  imports: [ CommonModule ],
+  declarations: [ SampleComponent ],
+  exports: [ SampleComponent ]
 })
 export class SampleModule {}

--- a/src/app/sort/example/sort-example.module.ts
+++ b/src/app/sort/example/sort-example.module.ts
@@ -15,9 +15,9 @@ import { SortExampleComponent } from './sort-example.component';
     SortModule,
     TabsModule.forRoot()
   ],
-  declarations: [SortExampleComponent],
-  exports: [SortExampleComponent],
-  providers: [TabsetConfig]
+  declarations: [ SortExampleComponent ],
+  exports: [ SortExampleComponent ],
+  providers: [ TabsetConfig ]
 })
 export class SortExampleModule {
   constructor() {}

--- a/src/app/sort/sort.component.spec.ts
+++ b/src/app/sort/sort.component.spec.ts
@@ -44,9 +44,9 @@ describe('Sort component - ', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, BsDropdownModule.forRoot(), FormsModule],
-      declarations: [SortComponent],
-      providers: [BsDropdownConfig]
+      imports: [ BrowserAnimationsModule, BsDropdownModule.forRoot(), FormsModule ],
+      declarations: [ SortComponent ],
+      providers: [ BsDropdownConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/sort/sort.module.ts
+++ b/src/app/sort/sort.module.ts
@@ -18,9 +18,9 @@ export {
  * A module containing objects associated with the sort component
  */
 @NgModule({
-  imports: [CommonModule, BsDropdownModule.forRoot()],
-  declarations: [SortComponent],
-  exports: [SortComponent],
-  providers: [BsDropdownConfig]
+  imports: [ CommonModule, BsDropdownModule.forRoot() ],
+  declarations: [ SortComponent ],
+  exports: [ SortComponent ],
+  providers: [ BsDropdownConfig ]
 })
 export class SortModule {}

--- a/src/app/table/basic-table/example/table-example.module.ts
+++ b/src/app/table/basic-table/example/table-example.module.ts
@@ -16,7 +16,7 @@ import { TableExpansionExampleComponent } from './table-expansion-example.compon
 import { TableGroupExampleComponent } from './table-group-example.component';
 import { TableViewExampleComponent } from './table-view-example.component';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { TableModule } from '../../table.module';
+import { TableModule } from '../table.module';
 import { ToolbarModule } from '../../../toolbar/toolbar.module';
 
 @NgModule({
@@ -41,7 +41,7 @@ import { ToolbarModule } from '../../../toolbar/toolbar.module';
     TabsModule.forRoot(),
     ToolbarModule
   ],
-  providers: [BsDropdownConfig, TabsetConfig]
+  providers: [ BsDropdownConfig, TabsetConfig ]
 })
 export class TableExampleModule {
   constructor() {}

--- a/src/app/table/basic-table/index.ts
+++ b/src/app/table/basic-table/index.ts
@@ -1,0 +1,5 @@
+export { NgxDataTableConfig } from './ngx-datatable-config';
+export { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
+export { TableComponent } from './table.component';
+export { TableConfig } from './table-config';
+export { TableModule } from './table.module';

--- a/src/app/table/basic-table/table.component.spec.ts
+++ b/src/app/table/basic-table/table.component.spec.ts
@@ -25,9 +25,9 @@ import { FilterConfig } from '../../filter/filter-config';
 import { FilterField } from '../../filter/filter-field';
 import { FilterType } from '../../filter/filter-type';
 import { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
-import { PipeModule } from './../../pipe/pipe.module';
 import { PaginationConfig } from './../../pagination/pagination-config';
 import { PaginationModule } from './../../pagination/pagination.module';
+import { SearchHighlightPipeModule } from '../../pipe/search-highlight/search-highlight.pipe.module';
 import { SortConfig } from '../../sort/sort-config';
 import { SortEvent } from '../../sort/sort-event';
 import { TableComponent } from './table.component';
@@ -297,9 +297,9 @@ describe('Table component - ', () => {
         EmptyStateModule,
         FormsModule,
         PaginationModule,
-        PipeModule,
         PopoverModule.forRoot(),
         NgxDatatableModule,
+        SearchHighlightPipeModule,
         ToolbarModule,
         TooltipModule.forRoot()
       ],
@@ -307,7 +307,7 @@ describe('Table component - ', () => {
         TableComponent,
         NgxDataTableDndDirective
       ],
-      providers: [BsDropdownConfig, TooltipConfig, DragulaService]
+      providers: [ BsDropdownConfig, TooltipConfig, DragulaService ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/table/basic-table/table.module.ts
+++ b/src/app/table/basic-table/table.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { DragulaModule, DragulaService } from 'ng2-dragula';
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+
+import { PaginationModule } from '../../pagination/pagination.module';
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { NgxDataTableConfig } from './ngx-datatable-config';
+import { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
+import { TableComponent } from './table.component';
+import { TableConfig } from './table-config';
+import { TableEvent } from '../table-event';
+import { ToolbarModule } from '../../toolbar/toolbar.module';
+
+export {
+  NgxDataTableConfig,
+  TableConfig,
+  TableEvent
+};
+
+/**
+ * A module containing objects associated with table components
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    DragulaModule,
+    EmptyStateModule,
+    FormsModule,
+    PaginationModule,
+    NgxDatatableModule,
+    ToolbarModule
+  ],
+  declarations: [ NgxDataTableDndDirective, TableComponent ],
+  exports: [ TableComponent ],
+  providers: [ DragulaService ]
+})
+export class TableModule {}

--- a/src/app/table/index.ts
+++ b/src/app/table/index.ts
@@ -1,8 +1,6 @@
-export { NgxDataTableConfig } from './basic-table/ngx-datatable-config';
-export { NgxDataTableDndDirective } from './basic-table/ngx-datatable-dnd.directive';
 export { TableBase } from './table-base';
-export { TableComponent } from './basic-table/table.component';
-export { TableConfig } from './basic-table/table-config';
 export { TableConfigBase } from './table-config-base';
 export { TableEvent } from './table-event';
 export { TableModule } from './table.module';
+
+export * from './basic-table/index';

--- a/src/app/table/table.module.ts
+++ b/src/app/table/table.module.ts
@@ -26,6 +26,12 @@ export {
 
 /**
  * A module containing objects associated with table components
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   TableModule // basic table
+ * } from 'patternfly-ng/table';
  */
 @NgModule({
   imports: [
@@ -37,8 +43,12 @@ export {
     NgxDatatableModule,
     ToolbarModule
   ],
-  declarations: [NgxDataTableDndDirective, TableComponent],
-  exports: [TableComponent],
-  providers: [DragulaService]
+  declarations: [ NgxDataTableDndDirective, TableComponent ],
+  exports: [ TableComponent ],
+  providers: [ DragulaService ]
 })
-export class TableModule {}
+export class TableModule {
+  constructor() {
+    console.log('patternfly-ng: TableModule is deprecated; use TableModule for basic table only');
+  }
+}

--- a/src/app/toolbar/example/toolbar-example.module.ts
+++ b/src/app/toolbar/example/toolbar-example.module.ts
@@ -12,7 +12,7 @@ import { ToolbarExampleComponent } from './toolbar-example.component';
 import { ToolbarModule } from '../toolbar.module';
 
 @NgModule({
-  declarations: [ToolbarExampleComponent],
+  declarations: [ ToolbarExampleComponent ],
   imports: [
     ActionModule,
     BsDropdownModule.forRoot(),
@@ -23,7 +23,7 @@ import { ToolbarModule } from '../toolbar.module';
     TabsModule.forRoot(),
     ToolbarModule
   ],
-  providers: [BsDropdownConfig, TabsetConfig]
+  providers: [ BsDropdownConfig, TabsetConfig ]
 })
 export class ToolbarExampleModule {
   constructor() {}

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -22,13 +22,14 @@ import { FilterField } from '../filter/filter-field';
 import { FilterFieldsComponent } from '../filter/filter-fields.component';
 import { FilterResultsComponent } from '../filter/filter-results.component';
 import { FilterType } from '../filter/filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
 import { SortComponent } from '../sort/sort.component';
 import { SortConfig } from '../sort/sort-config';
 import { SortEvent } from '../sort/sort-event';
 import { ToolbarComponent } from './toolbar.component';
 import { ToolbarConfig } from './toolbar-config';
 import { ToolbarView } from './toolbar-view';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 describe('Toolbar component - ', () => {
   let comp: ToolbarComponent;
@@ -182,15 +183,16 @@ describe('Toolbar component - ', () => {
         BsDropdownModule.forRoot(),
         BrowserAnimationsModule,
         FormsModule,
-        PipeModule,
         PopoverModule.forRoot(),
-        TooltipModule.forRoot()
+        SearchHighlightPipeModule,
+        TooltipModule.forRoot(),
+        TruncatePipeModule
       ],
       declarations: [
         ToolbarComponent, FilterFieldsComponent,
         FilterResultsComponent, SortComponent
       ],
-      providers: [BsDropdownConfig, TooltipConfig]
+      providers: [ BsDropdownConfig, TooltipConfig ]
     })
       .compileComponents()
       .then(() => {

--- a/src/app/toolbar/toolbar.module.ts
+++ b/src/app/toolbar/toolbar.module.ts
@@ -24,8 +24,8 @@ export {
     FilterModule,
     SortModule
   ],
-  declarations: [ToolbarComponent],
-  exports: [ToolbarComponent],
-  providers: [BsDropdownConfig]
+  declarations: [ ToolbarComponent ],
+  exports: [ ToolbarComponent ],
+  providers: [ BsDropdownConfig ]
 })
 export class ToolbarModule {}

--- a/src/app/wizard/example/wizard-example.module.ts
+++ b/src/app/wizard/example/wizard-example.module.ts
@@ -29,7 +29,7 @@ import { WizardModule } from '../wizard.module';
     TabsModule.forRoot(),
     WizardModule
   ],
-  providers: [TabsetConfig]
+  providers: [ TabsetConfig ]
 })
 export class WizardExampleModule {
   constructor() {}

--- a/src/app/wizard/wizard.module.ts
+++ b/src/app/wizard/wizard.module.ts
@@ -29,8 +29,8 @@ export {
     CommonModule,
     TooltipModule.forRoot()
   ],
-  declarations: [WizardComponent, WizardReviewComponent, WizardStepComponent, WizardSubstepComponent],
-  exports: [WizardComponent, WizardReviewComponent, WizardStepComponent, WizardSubstepComponent],
-  providers: [TooltipConfig]
+  declarations: [ WizardComponent, WizardReviewComponent, WizardStepComponent, WizardSubstepComponent ],
+  exports: [ WizardComponent, WizardReviewComponent, WizardStepComponent, WizardSubstepComponent ],
+  providers: [ TooltipConfig ]
 })
 export class WizardModule {}

--- a/src/demo/components/demo-components.module.ts
+++ b/src/demo/components/demo-components.module.ts
@@ -5,7 +5,7 @@ import { IncludeContentComponent } from './includeContent.component';
 import { IncludeMarkdownComponent } from './includeMarkdown.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [ CommonModule ],
   exports: [
     IncludeContentComponent,
     IncludeMarkdownComponent

--- a/src/demo/navbar/navbar.module.ts
+++ b/src/demo/navbar/navbar.module.ts
@@ -16,7 +16,7 @@ import { NavbarTopComponent } from './navbar-top.component';
     CommonModule,
     FormsModule
   ],
-  declarations: [NavbarComponent, NavbarSideComponent, NavbarTopComponent],
-  exports: [NavbarComponent, NavbarSideComponent, NavbarTopComponent]
+  declarations: [ NavbarComponent, NavbarSideComponent, NavbarTopComponent ],
+  exports: [ NavbarComponent, NavbarSideComponent, NavbarTopComponent ]
 })
 export class NavbarModule {}


### PR DESCRIPTION
This allows components to be imported individually without having to install an unused, optional dependency. For example, the basic list component can now be imported without the angular-tree-component dependency required by tree list.

Example:
https://rawgit.com/dlabrecq/patternfly-ng/test-dist/dist-demo/#

Deprecated classes:

- ChartConfig: 
  - Use ChartConfigBase, DonutChartConfig, or SparklineChartConfig
- DonutConfig
  - Use DonutChartConfig or UtilizationDonutChartConfig
- SparklineComponent
  - Use SparklineChartComponent
- SparklineConfig
  - Use SparklineChartConfig
- SparklineData
  - Use SparklineChartData
- NavigationItemConfig
  - Use NavigationBaseConfig, VerticalNavigationConfig, or ApplicationLauncherConfig

Deprecated modules:

- CardModule
  - Use InfoStatusCardModule and CardModule for basic card only
- ChartModule
  - Use DonutChartModule and SparklineChartModule
- ListModule
  - Use TreeListModule and ListModule for basic list only
- PipeModule
  - Use SearchHighlightModule, SortArrayModule, or TruncateModule
- TableModule
  - Use TableModule for table only
- NavigationModule
  - Use ApplicationLauncherModule or VerticalNavigationModule
- NotificationModule
  - Use InlineNotificationModule, NotificationDrawerModule, NotificationServiceModule, ToastNotificationModule, or ToastNotificationListModule

Updated: This merge was backed out. The Travis build appears to have memory issues with `git commit` for dist and dist-demo.