### PR TITLE
fix(toolbar): give accessible name to sort and more actions button

### DIFF
--- a/src/app/action/action-config.ts
+++ b/src/app/action/action-config.ts
@@ -11,6 +11,11 @@ export class ActionConfig {
   moreActions?: Action[];
 
   /**
+   * Text announced to screen readers for the action config button
+   */
+  moreActionsAriaLabel?: string;
+  
+  /**
    * Set to true to disable secondary actions
    */
   moreActionsDisabled: boolean;
@@ -29,9 +34,4 @@ export class ActionConfig {
    * List of primary actions (e.g., for buttons)
    */
   primaryActions: Action[];
-
-  /**
-   * Text announced to screen readers for the action config button
-   */
-  ariaLabel?: string;
 }

--- a/src/app/action/action-config.ts
+++ b/src/app/action/action-config.ts
@@ -29,4 +29,9 @@ export class ActionConfig {
    * List of primary actions (e.g., for buttons)
    */
   primaryActions: Action[];
+
+  /**
+   * Text announced to screen readers for the action config button
+   */
+  ariaLabel?: string;
 }

--- a/src/app/action/action.component.html
+++ b/src/app/action/action.component.html
@@ -23,7 +23,8 @@
      *ngIf="config.moreActions?.length > 0">
   <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle
           [ngClass]="{'disabled': config.moreActionsDisabled}"
-          (click)="initMoreActionsDropup($event)">
+          (click)="initMoreActionsDropup($event)"
+          aria-label="More Actions">
     <span class="fa fa-ellipsis-v"></span>
   </button>
   <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>

--- a/src/app/action/action.component.html
+++ b/src/app/action/action.component.html
@@ -24,7 +24,7 @@
   <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle
           [ngClass]="{'disabled': config.moreActionsDisabled}"
           (click)="initMoreActionsDropup($event)"
-          [attr.aria-label]="config.moreActionsAriaLabel || 'More Actions'">
+          [attr.aria-label]="config.moreActionsAriaLabel">
     <span class="fa fa-ellipsis-v"></span>
   </button>
   <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>

--- a/src/app/action/action.component.html
+++ b/src/app/action/action.component.html
@@ -24,7 +24,7 @@
   <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle
           [ngClass]="{'disabled': config.moreActionsDisabled}"
           (click)="initMoreActionsDropup($event)"
-          aria-label="More Actions">
+          [attr.aria-label]="config.ariaLabel || 'More Actions'">
     <span class="fa fa-ellipsis-v"></span>
   </button>
   <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>

--- a/src/app/action/action.component.html
+++ b/src/app/action/action.component.html
@@ -24,7 +24,7 @@
   <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle
           [ngClass]="{'disabled': config.moreActionsDisabled}"
           (click)="initMoreActionsDropup($event)"
-          [attr.aria-label]="config.ariaLabel || 'More Actions'">
+          [attr.aria-label]="config.moreActionsAriaLabel || 'More Actions'">
     <span class="fa fa-ellipsis-v"></span>
   </button>
   <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>

--- a/src/app/filter/filter-fields.component.html
+++ b/src/app/filter/filter-fields.component.html
@@ -5,7 +5,7 @@
               tooltip="Filter by" placement="{{config?.tooltipPlacement}}"
               [disabled]="config.disabled === true">
         {{currentField?.title}}
-        <span class="caret"></span>
+        <span aria-hidden="true" class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" *dropdownMenu>
         <li role="menuitem" *ngFor="let field of config?.fields"
@@ -30,7 +30,7 @@
         <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
                 [disabled]="config.disabled === true">
           <span class="filter-option pull-left">{{currentValue || currentField?.placeholder}}</span>
-          <span class="caret"></span>
+          <span aria-hidden="true" class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu" *dropdownMenu>
           <li role="menuitem" *ngIf="currentField?.placeholder">

--- a/src/app/sort/sort.component.html
+++ b/src/app/sort/sort.component.html
@@ -3,7 +3,7 @@
     <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
             [disabled]="config.disabled === true">
       {{currentField?.title}}
-      <span class="caret"></span>
+      <span aria-hidden="true" class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu" *dropdownMenu>
       <li role="menuitem" *ngFor="let item of config?.fields" [ngClass]="{'selected': item === currentField}">
@@ -13,6 +13,7 @@
     </ul>
   </div>
   <button class="btn btn-link" type="button"
+          aria-label="Sort Direction"
           [disabled]="config.disabled === true"
           (click)="onChangeDirection()">
     <span class="sort-direction" [ngClass]="getIconStyleClass()"></span>

--- a/src/app/toolbar/example/toolbar-example.component.html
+++ b/src/app/toolbar/example/toolbar-example.component.html
@@ -19,7 +19,7 @@
           <ng-template #actionTemplate>
             <span class="dropdown primary-action" dropdown>
               <button class="btn btn-default dropdown-toggle" type="button" dropdownToggle>
-                Menu Action<span class="caret"></span>
+                Menu Action<span aria-hidden="true" class="caret"></span>
               </button>
               <ul class="dropdown-menu" role="menu" *dropdownMenu>
                 <li role="menuitem">
@@ -37,7 +37,7 @@
               </ul>
             </span>
             <button class="btn btn-default primary-action" type="button" (click)="doAdd()">
-              <span class="fa fa-plus"></span>
+              <span aria-hidden="true" class="fa fa-plus"></span>
               Add Action
             </button>
           </ng-template>

--- a/src/app/toolbar/toolbar-view.ts
+++ b/src/app/toolbar/toolbar-view.ts
@@ -21,4 +21,9 @@ export class ToolbarView {
    * A tooltip for the view selector
    */
   tooltip?: string;
+
+  /**
+   * Text announced to screen readers for the action config button
+   */
+  ariaLabel?: string;
 }

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -29,7 +29,7 @@
             <button *ngFor="let view of config.views"
                     class="btn btn-link"
                     [ngClass]="{'active': isViewSelected(view), 'disabled': view.disabled === true}"
-                    [attr.aria-label]="view.tooltip"
+                    [attr.aria-label]="view.ariaLabel || view.tooltip"
                     title={{view.tooltip}}
                     (click)="viewSelected(view)">
               <i class="{{view.iconStyleClass}}"></i>

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -26,9 +26,12 @@
              *ngIf="viewTemplate !== undefined || (config.views)">
           <ng-template [ngTemplateOutlet]="viewTemplate" [ngTemplateOutletContext]="{}"></ng-template>
           <span *ngIf="config.views">
-            <button *ngFor="let view of config.views" class="btn btn-link"
+            <button *ngFor="let view of config.views"
+                    class="btn btn-link"
                     [ngClass]="{'active': isViewSelected(view), 'disabled': view.disabled === true}"
-                    title={{view.tooltip}}  (click)="viewSelected(view)">
+                    [attr.aria-label]="view.tooltip"
+                    title={{view.tooltip}}
+                    (click)="viewSelected(view)">
               <i class="{{view.iconStyleClass}}"></i>
             </button>
           </span>


### PR DESCRIPTION
This PR makes some small but impactful changes to accessible text found in the toolbar. The Sort and More Actions buttons where not displaying in the rotor menu at all, but with this PR they are properly labelled. This also cleans up the various icons that simply needed to be hidden.

hide icons from screen readers
use accessible names
ensure accessible names appear for cursor navigation or rotor

Demo should be available from link below once travis finishes
https://rawgit.com/seanforyou23/patternfly-ng/a11y-adjustments-dist/dist-demo/

![fixed](https://user-images.githubusercontent.com/5942899/41434130-c0f186d4-6fe8-11e8-8623-6547f6f5587a.jpg)
