### PR TITLE
Individual module imports for card components

### DIFF
--- a/src/app/card/basic-card/card.module.ts
+++ b/src/app/card/basic-card/card.module.ts
@@ -2,13 +2,19 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
+import { CardAction } from '../card-action/card-action';
 import { CardActionModule } from '../card-action/card-action.module';
 import { CardComponent } from '../basic-card/card.component';
 import { CardConfig } from '../basic-card/card-config';
+import { CardFilter } from '../card-filter/card-filter';
 import { CardFilterModule } from '../card-filter/card-filter.module';
+import { CardFilterPosition } from '../card-filter/card-filter-position';
 
 export {
-  CardConfig
+  CardAction,
+  CardConfig,
+  CardFilter,
+  CardFilterPosition
 };
 
 /**

--- a/src/app/card/basic-card/example/card-basic-example.component.ts
+++ b/src/app/card/basic-card/example/card-basic-example.component.ts
@@ -7,8 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
-import { SparklineConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
-import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-data';
+import { SparklineChartConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
+import { SparklineChartData } from '../../../chart/sparkline-chart/sparkline-chart-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -18,12 +18,12 @@ import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-da
 export class CardBasicExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfig: SparklineConfig = {
+  chartConfig: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'exampleSparkline',
     tooltipType: 'default'
   };
-  chartData: SparklineData = {
+  chartData: SparklineChartData = {
     dataAvailable: true,
     total: 100,
     xData: this.chartDates,

--- a/src/app/card/basic-card/example/card-trend-example.component.ts
+++ b/src/app/card/basic-card/example/card-trend-example.component.ts
@@ -7,8 +7,8 @@ import {
 import { CardAction } from '../../card-action/card-action';
 import { CardConfig } from '../card-config';
 import { CardFilter } from '../../card-filter/card-filter';
-import { SparklineConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
-import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-data';
+import { SparklineChartConfig } from '../../../chart/sparkline-chart/sparkline-chart-config';
+import { SparklineChartData } from '../../../chart/sparkline-chart/sparkline-chart-data';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -18,12 +18,12 @@ import { SparklineData } from '../../../chart/sparkline-chart/sparkline-chart-da
 export class CardTrendExampleComponent implements OnInit {
   actionsText: string = '';
   chartDates: any[] = ['dates'];
-  chartConfigVirtual: SparklineConfig = {
+  chartConfigVirtual: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'virtualTrendsChart',
     tooltipType: 'default'
   };
-  chartDataVirtual: SparklineData = {
+  chartDataVirtual: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -31,12 +31,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '90', '20', '30', '20', '20', '10', '14', '20', '25',
       '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
   };
-  chartConfigPhysical: SparklineConfig = {
+  chartConfigPhysical: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'physicalTrendsChart',
     tooltipType: 'default'
   };
-  chartDataPhysical: SparklineData = {
+  chartDataPhysical: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,
@@ -44,12 +44,12 @@ export class CardTrendExampleComponent implements OnInit {
       'used', '20', '20', '35', '20', '20', '87', '14', '20', '25',
       '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
   };
-  chartConfigMemory: SparklineConfig = {
+  chartConfigMemory: SparklineChartConfig = {
     chartHeight: 60,
     chartId: 'memoryTrendsChart',
     tooltipType: 'default'
   };
-  chartDataMemory: SparklineData = {
+  chartDataMemory: SparklineChartData = {
     dataAvailable: true,
     total: 250,
     xData: this.chartDates,

--- a/src/app/card/basic-card/index.ts
+++ b/src/app/card/basic-card/index.ts
@@ -1,4 +1,3 @@
 export { CardComponent } from './card.component';
 export { CardConfig } from './card-config';
 export { CardModule } from './card.module';
-export { CardModule as BasicCardModule } from './card.module';

--- a/src/app/card/card.module.ts
+++ b/src/app/card/card.module.ts
@@ -31,7 +31,12 @@ export {
 /**
  * A module containing objects associated with card components
  *
- * @deprecated Use BasicCardModule or InfoStatusCardModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   CardModule, // basic card only
+ *   InfoStatusCardModule
+ * } from 'patternfy/card';
  */
 @NgModule({
   imports: [
@@ -44,4 +49,8 @@ export {
   ],
   exports: [CardComponent, CardFilterComponent, InfoStatusCardComponent]
 })
-export class CardModule {}
+export class CardModule {
+  constructor() {
+    console.log('patternfly-ng: CardModule is deprecated; use InfoStatusCardModule or CardModule for basic card only');
+  }
+}

--- a/src/app/card/index.ts
+++ b/src/app/card/index.ts
@@ -1,6 +1,6 @@
 export { CardBase } from './card-base';
 export { CardConfigBase } from './card-config-base';
-export { CardModule } from './card.module';
+export { CardModule } from './card.module'; // @deprecated
 
 export * from './card-action/index';
 export * from './basic-card/index';

--- a/src/app/card/info-status-card/example/info-status-card-example.module.ts
+++ b/src/app/card/info-status-card/example/info-status-card-example.module.ts
@@ -19,7 +19,7 @@ import { DemoComponentsModule } from '../../../../demo/components/demo-component
     InfoStatusCardModule,
     TabsModule.forRoot()
   ],
-  providers: [ TabsetConfig ]
+  providers: [TabsetConfig]
 })
 export class InfoStatusCardExampleModule {
   constructor() {}


### PR DESCRIPTION
Individual module imports for card components.

This allows components to be imported individually without having to install an unused, optional dependency.

Deprecations

- CardModule: Use InfoStatusCardModule and CardModule for basic card only

Note: Backed out https://github.com/patternfly/patternfly-ng/pull/377 to address a `git commit` issue with Travis. Adding code back in one module at a time.