### PR TITLE
Individual module imports for pipe directives

### DIFF
--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -20,7 +20,8 @@ import { FilterField } from './filter-field';
 import { FilterFieldsComponent } from './filter-fields.component';
 import { FilterResultsComponent } from './filter-results.component';
 import { FilterType } from './filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 describe('Filter component - ', () => {
   let comp: FilterComponent;
@@ -125,9 +126,10 @@ describe('Filter component - ', () => {
         BsDropdownModule.forRoot(),
         BrowserAnimationsModule,
         FormsModule,
-        PipeModule,
         PopoverModule.forRoot(),
-        TooltipModule.forRoot()
+        SearchHighlightPipeModule,
+        TooltipModule.forRoot(),
+        TruncatePipeModule
       ],
       declarations: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],
       providers: [BsDropdownConfig, TooltipConfig]

--- a/src/app/filter/filter.module.ts
+++ b/src/app/filter/filter.module.ts
@@ -15,7 +15,8 @@ import { FilterFieldsComponent } from './filter-fields.component';
 import { FilterResultsComponent } from './filter-results.component';
 import { FilterQuery } from './filter-query';
 import { FilterType } from './filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 export {
   Filter,
@@ -34,9 +35,10 @@ export {
     BsDropdownModule.forRoot(),
     CommonModule,
     FormsModule,
-    PipeModule,
     PopoverModule.forRoot(),
-    TooltipModule.forRoot()
+    SearchHighlightPipeModule,
+    TooltipModule.forRoot(),
+    TruncatePipeModule
   ],
   declarations: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],
   exports: [FilterComponent, FilterFieldsComponent, FilterResultsComponent],

--- a/src/app/list/basic-list/example/list-example.module.ts
+++ b/src/app/list/basic-list/example/list-example.module.ts
@@ -19,7 +19,7 @@ import { ListHeadingExampleComponent } from './list-heading-example.component';
 import { ListExampleComponent } from './list-example.component';
 import { ListPinExampleComponent } from './list-pin-example.component';
 import { NodesContentComponent } from './content/nodes-content.component';
-import { PipeModule } from '../../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../../pipe/sort-array';
 
 @NgModule({
   declarations: [
@@ -41,7 +41,7 @@ import { PipeModule } from '../../../pipe/pipe.module';
     DemoComponentsModule,
     FormsModule,
     ListModule,
-    PipeModule,
+    SortArrayPipeModule,
     TabsModule.forRoot(),
     TooltipModule.forRoot()
   ],

--- a/src/app/list/basic-list/list.component.spec.ts
+++ b/src/app/list/basic-list/list.component.spec.ts
@@ -13,7 +13,7 @@ import { EmptyStateConfig } from '../../empty-state/empty-state-config';
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { ListComponent } from './list.component';
 import { ListConfig } from './list-config';
-import { PipeModule } from '../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../pipe/sort-array/sort-array.pipe.module';
 
 describe('List component - ', () => {
   let comp: ListComponent;
@@ -121,7 +121,7 @@ describe('List component - ', () => {
         BrowserAnimationsModule,
         EmptyStateModule,
         FormsModule,
-        PipeModule
+        SortArrayPipeModule
       ],
       declarations: [ListComponent],
       providers: []

--- a/src/app/list/basic-list/list.module.ts
+++ b/src/app/list/basic-list/list.module.ts
@@ -7,7 +7,7 @@ import { ListComponent } from './list.component';
 import { ListConfig } from './list-config';
 import { ListEvent } from '../list-event';
 import { ListExpandToggleComponent } from './list-expand-toggle.component';
-import { PipeModule } from '../../pipe/pipe.module';
+import { SortArrayPipeModule } from '../../pipe/sort-array/sort-array.pipe.module';
 
 export {
   ListConfig,
@@ -22,7 +22,7 @@ export {
     CommonModule,
     EmptyStateModule,
     FormsModule,
-    PipeModule
+    SortArrayPipeModule
   ],
   declarations: [ListComponent, ListExpandToggleComponent],
   exports: [ListComponent, ListExpandToggleComponent]

--- a/src/app/pipe/index.ts
+++ b/src/app/pipe/index.ts
@@ -1,4 +1,5 @@
 export { PipeModule } from './pipe.module';
-export { SearchHighlightPipe } from './search-highlight/search-highlight.pipe';
-export { SortArrayPipe } from './sort-array/sort-array.pipe';
-export { TruncatePipe } from './truncate/truncate.pipe';
+
+export * from './search-highlight/index';
+export * from './sort-array/index';
+export * from './truncate/index';

--- a/src/app/pipe/pipe.module.ts
+++ b/src/app/pipe/pipe.module.ts
@@ -1,21 +1,39 @@
 import { NgModule } from '@angular/core';
+
+import { SearchHighlightPipeModule } from './search-highlight/search-highlight.pipe.module';
 import { SearchHighlightPipe } from './search-highlight/search-highlight.pipe';
+import { SortArrayPipeModule } from './sort-array/sort-array.pipe.module';
 import { SortArrayPipe } from './sort-array/sort-array.pipe';
+import { TruncatePipeModule } from './truncate/truncate.pipe.module';
 import { TruncatePipe } from './truncate/truncate.pipe';
+
+export {
+  SearchHighlightPipe,
+  SortArrayPipe,
+  TruncatePipe
+};
 
 /**
  * A module containing objects associated with pipes
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   SearchHighlightModule,
+ *   SortArrayModule,
+ *   TruncateModule
+ * } from 'patternfly-ng/pipe';
  */
 @NgModule({
-  declarations: [
-    SearchHighlightPipe,
-    SortArrayPipe,
-    TruncatePipe
-  ],
-  exports: [
-    SearchHighlightPipe,
-    SortArrayPipe,
-    TruncatePipe
+  imports: [
+    SearchHighlightPipeModule,
+    SortArrayPipeModule,
+    TruncatePipeModule
   ]
 })
-export class PipeModule { }
+export class PipeModule {
+  constructor() {
+    console.log('patternfly-ng: PipeModule is deprecated; use SearchHighlightModule, ' +
+      'SortArrayModule, or TruncateModule');
+  }
+}

--- a/src/app/pipe/search-highlight/example/search-highlight-example.module.ts
+++ b/src/app/pipe/search-highlight/example/search-highlight-example.module.ts
@@ -4,8 +4,8 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { SearchHighlightExampleComponent } from './search-highlight-example.component';
+import { SearchHighlightPipeModule } from '../search-highlight.pipe.module';
 
 @NgModule({
   declarations: [SearchHighlightExampleComponent],
@@ -13,7 +13,7 @@ import { SearchHighlightExampleComponent } from './search-highlight-example.comp
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
+    SearchHighlightPipeModule,
     TabsModule.forRoot(),
   ],
   providers: [TabsetConfig]

--- a/src/app/pipe/search-highlight/index.ts
+++ b/src/app/pipe/search-highlight/index.ts
@@ -1,0 +1,2 @@
+export { SearchHighlightPipeModule } from './search-highlight.pipe.module';
+export { SearchHighlightPipe } from './search-highlight.pipe';

--- a/src/app/pipe/search-highlight/search-highlight.pipe.module.ts
+++ b/src/app/pipe/search-highlight/search-highlight.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { SearchHighlightPipe } from './search-highlight.pipe';
+
+/**
+ * A module containing objects associated with the search highlight pipe
+ */
+@NgModule({
+  declarations: [
+    SearchHighlightPipe
+  ],
+  exports: [
+    SearchHighlightPipe
+  ]
+})
+export class SearchHighlightPipeModule { }

--- a/src/app/pipe/sort-array/example/sort-array-example.module.ts
+++ b/src/app/pipe/sort-array/example/sort-array-example.module.ts
@@ -4,19 +4,19 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { SortArrayExampleComponent } from './sort-array-example.component';
+import { SortArrayPipeModule } from '../sort-array.pipe.module';
 
 @NgModule({
-  declarations: [ SortArrayExampleComponent ],
+  declarations: [SortArrayExampleComponent],
   imports: [
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
+    SortArrayPipeModule,
     TabsModule.forRoot()
   ],
-  providers: [ TabsetConfig ]
+  providers: [TabsetConfig]
 })
 export class SortArrayExampleModule {
   constructor() {}

--- a/src/app/pipe/sort-array/index.ts
+++ b/src/app/pipe/sort-array/index.ts
@@ -1,0 +1,2 @@
+export { SortArrayPipeModule } from './sort-array.pipe.module';
+export { SortArrayPipe } from './sort-array.pipe';

--- a/src/app/pipe/sort-array/sort-array.pipe.module.ts
+++ b/src/app/pipe/sort-array/sort-array.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { SortArrayPipe } from './sort-array.pipe';
+
+/**
+ * A module containing objects associated with the sort array pipe
+ */
+@NgModule({
+  declarations: [
+    SortArrayPipe
+  ],
+  exports: [
+    SortArrayPipe
+  ]
+})
+export class SortArrayPipeModule { }

--- a/src/app/pipe/truncate/example/truncate-example.module.ts
+++ b/src/app/pipe/truncate/example/truncate-example.module.ts
@@ -4,19 +4,19 @@ import { NgModule }  from '@angular/core';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { PipeModule } from '../../pipe.module';
 import { TruncateExampleComponent } from './truncate-example.component';
+import { TruncatePipeModule } from '../truncate.pipe.module';
 
 @NgModule({
-  declarations: [ TruncateExampleComponent ],
+  declarations: [TruncateExampleComponent],
   imports: [
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    PipeModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    TruncatePipeModule
   ],
-  providers: [ TabsetConfig ]
+  providers: [TabsetConfig]
 })
 export class TruncateExampleModule {
   constructor() {}

--- a/src/app/pipe/truncate/index.ts
+++ b/src/app/pipe/truncate/index.ts
@@ -1,0 +1,2 @@
+export { TruncatePipeModule } from './truncate.pipe.module';
+export { TruncatePipe } from './truncate.pipe';

--- a/src/app/pipe/truncate/truncate.pipe.module.ts
+++ b/src/app/pipe/truncate/truncate.pipe.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { TruncatePipe } from './truncate.pipe';
+
+/**
+ * A module containing objects associated with the truncate pipe
+ */
+@NgModule({
+  declarations: [
+    TruncatePipe
+  ],
+  exports: [
+    TruncatePipe
+  ]
+})
+export class TruncatePipeModule { }

--- a/src/app/table/basic-table/table.component.spec.ts
+++ b/src/app/table/basic-table/table.component.spec.ts
@@ -25,7 +25,6 @@ import { FilterConfig } from '../../filter/filter-config';
 import { FilterField } from '../../filter/filter-field';
 import { FilterType } from '../../filter/filter-type';
 import { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
-import { PipeModule } from './../../pipe/pipe.module';
 import { PaginationConfig } from './../../pagination/pagination-config';
 import { PaginationModule } from './../../pagination/pagination.module';
 import { SortConfig } from '../../sort/sort-config';
@@ -297,7 +296,6 @@ describe('Table component - ', () => {
         EmptyStateModule,
         FormsModule,
         PaginationModule,
-        PipeModule,
         PopoverModule.forRoot(),
         NgxDatatableModule,
         ToolbarModule,

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -22,13 +22,14 @@ import { FilterField } from '../filter/filter-field';
 import { FilterFieldsComponent } from '../filter/filter-fields.component';
 import { FilterResultsComponent } from '../filter/filter-results.component';
 import { FilterType } from '../filter/filter-type';
-import { PipeModule } from './../pipe/pipe.module';
+import { SearchHighlightPipeModule } from '../pipe/search-highlight/search-highlight.pipe.module';
 import { SortComponent } from '../sort/sort.component';
 import { SortConfig } from '../sort/sort-config';
 import { SortEvent } from '../sort/sort-event';
 import { ToolbarComponent } from './toolbar.component';
 import { ToolbarConfig } from './toolbar-config';
 import { ToolbarView } from './toolbar-view';
+import { TruncatePipeModule } from '../pipe/truncate/truncate.pipe.module';
 
 describe('Toolbar component - ', () => {
   let comp: ToolbarComponent;
@@ -182,9 +183,10 @@ describe('Toolbar component - ', () => {
         BsDropdownModule.forRoot(),
         BrowserAnimationsModule,
         FormsModule,
-        PipeModule,
         PopoverModule.forRoot(),
-        TooltipModule.forRoot()
+        SearchHighlightPipeModule,
+        TooltipModule.forRoot(),
+        TruncatePipeModule
       ],
       declarations: [
         ToolbarComponent, FilterFieldsComponent,


### PR DESCRIPTION
 Individual module imports for pipe directives.

This allows components to be imported individually without having to install an unused, optional dependency.

Deprecated modules:

- PipeModule: Use SearchHighlightModule, SortArrayModule, or TruncateModule

Note: Backed out #377 to address a git commit issue with Travis. Adding code back in one module at a time.