### PR TITLE
Individual module imports for chart components

### DIFF
--- a/src/app/chart/chart-config-base.ts
+++ b/src/app/chart/chart-config-base.ts
@@ -14,3 +14,13 @@ export abstract class ChartConfigBase {
    */
   data?: any;
 }
+
+/**
+ * @deprecated Use ChartConfigBase
+ */
+export abstract class ChartConfig extends ChartConfigBase {
+  constructor() {
+    super();
+    console.log('patternfly-ng: ChartConfig is deprecated; use ChartConfigBase');
+  }
+}

--- a/src/app/chart/chart.module.ts
+++ b/src/app/chart/chart.module.ts
@@ -17,7 +17,11 @@ import { WindowReference } from '../utilities/window.reference';
 export {
   ChartBase,
   ChartConfigBase,
-  ChartDefaults,
+  ChartDefaults
+};
+
+// @deprecated Use DonutChartComponent, SparklineChartConfig, and SparklineChartData
+export {
   DonutConfig,
   SparklineConfig,
   SparklineData
@@ -26,7 +30,12 @@ export {
 /**
  * A module containing objects associated with chart components
  *
- * @deprecated Use Use DonutChartModule or SparklineChartModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   DonutChartModule,
+ *   SparklineChartModule
+ * } from 'patterfnly/chart';
  */
 @NgModule({
   imports: [
@@ -35,8 +44,11 @@ export {
     FormsModule,
     SparklineChartModule
   ],
-  declarations: [DonutComponent, SparklineComponent],
   exports: [DonutComponent, SparklineComponent],
   providers: [ChartDefaults, WindowReference]
 })
-export class ChartModule {}
+export class ChartModule {
+  constructor() {
+    console.log('patternfly-ng: ChartModule is deprecated; use DonutChartModule or SparklineChartModule');
+  }
+}

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart-config.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart-config.ts
@@ -10,4 +10,8 @@ export class DonutChartConfig extends DonutChartBaseConfig {
  * @deprecated Use DonutChartConfig
  */
 export class DonutConfig extends DonutChartConfig {
+  constructor() {
+    super();
+    console.log('patternfly-ng: DonutConfig is deprecated; use DonutChartConfig or UtilizationDonutChartConfig');
+  }
 }

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.ts
@@ -41,4 +41,9 @@ export class DonutChartComponent extends DonutChartBaseComponent {
   selector: 'pfng-chart-donut',
   templateUrl: './donut-chart.component.html'
 })
-export class DonutComponent extends DonutChartComponent {}
+export class DonutComponent extends DonutChartComponent {
+  constructor(protected chartDefaults: ChartDefaults, protected windowRef: WindowReference) {
+    super(chartDefaults, windowRef);
+    console.log('patternfly-ng: DonutComponent is deprecated; use DonutChartComponent');
+  }
+}

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
@@ -5,10 +5,11 @@ import { NgModule } from '@angular/core';
 import { ChartDefaults } from '../../chart-defaults';
 
 import { DonutChartConfig } from './donut-chart-config';
-import { DonutChartComponent } from './donut-chart.component';
+import { DonutChartComponent, DonutComponent } from './donut-chart.component';
 import { WindowReference } from '../../../utilities/window.reference';
 
 export {
+  ChartDefaults,
   DonutChartConfig,
 };
 
@@ -17,8 +18,8 @@ export {
     CommonModule,
     FormsModule,
   ],
-  declarations: [DonutChartComponent],
-  exports: [DonutChartComponent],
+  declarations: [DonutChartComponent, DonutComponent],
+  exports: [DonutChartComponent, DonutComponent],
   providers: [ChartDefaults, WindowReference]
 })
 export class DonutChartModule {}

--- a/src/app/chart/donut-chart/basic-donut-chart/index.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/index.ts
@@ -1,6 +1,3 @@
 export { DonutChartComponent } from './donut-chart.component';
 export { DonutChartConfig } from './donut-chart-config';
 export { DonutChartModule } from './donut-chart.module';
-
-export { DonutComponent } from './donut-chart.component'; // @deprecated Use DonutChartComponent
-export { DonutConfig } from './donut-chart-config'; // @deprecated Use DonutChartConfig

--- a/src/app/chart/donut-chart/index.ts
+++ b/src/app/chart/donut-chart/index.ts
@@ -1,18 +1,5 @@
 export { DonutChartBaseComponent } from './donut-chart-base.component';
 export { DonutChartBaseConfig } from './donut-chart-base-config';
 
-// Basic Donut
-export {
-  DonutChartComponent,
-  DonutChartConfig,
-  DonutChartModule,
-  DonutComponent, // @deprecated Use DonutChartComponent
-  DonutConfig // @deprecated Use DonutChartConfig
-} from './basic-donut-chart/index';
-
-// Utilization Donut
-export {
-  UtilizationDonutChartComponent,
-  UtilizationDonutChartConfig,
-  UtilizationDonutChartModule
-} from './utilization-donut-chart/index';
+export * from './basic-donut-chart/index';
+export * from './utilization-donut-chart/index';

--- a/src/app/chart/donut-chart/utilization-donut-chart/example/utilization-donut-chart-example.module.ts
+++ b/src/app/chart/donut-chart/utilization-donut-chart/example/utilization-donut-chart-example.module.ts
@@ -4,14 +4,12 @@ import { NgModule } from '@angular/core';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { ChartModule } from '../../../chart.module';
 import { DemoComponentsModule } from '../../../../../demo/components/demo-components.module';
 import { UtilizationDonutChartExampleComponent } from './utilization-donut-chart-example.component';
 import { UtilizationDonutChartModule } from '../utilization-donut-chart.module';
 
 @NgModule({
   imports: [
-    ChartModule,
     CommonModule,
     DemoComponentsModule,
     FormsModule,

--- a/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
+++ b/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
@@ -8,6 +8,7 @@ import { UtilizationDonutChartConfig } from './utilization-donut-chart-config';
 import { WindowReference } from '../../../utilities/window.reference';
 
 export {
+  ChartDefaults,
   UtilizationDonutChartConfig,
 };
 

--- a/src/app/chart/index.ts
+++ b/src/app/chart/index.ts
@@ -1,9 +1,16 @@
 export { ChartBase } from './chart-base';
 export { ChartConfigBase } from './chart-config-base';
 export { ChartDefaults } from './chart-defaults';
-export { ChartModule } from './chart.module'; // @deprecated Use DonutChartModule or SparklineChartModule
 
 export * from './donut-chart/index';
 export * from './donut-chart/basic-donut-chart/index';
 export * from './sparkline-chart/index';
 export * from './donut-chart/utilization-donut-chart/index';
+
+export { ChartConfig } from './chart-config-base'; // @deprecated
+export { ChartModule } from './chart.module'; // @deprecated
+export { DonutComponent } from './donut-chart/basic-donut-chart/donut-chart.component'; // @deprecated
+export { DonutConfig } from './donut-chart/basic-donut-chart/donut-chart-config'; // @deprecated
+export { SparklineComponent } from './sparkline-chart/sparkline-chart.component'; // @deprecated
+export { SparklineConfig } from './sparkline-chart/sparkline-chart-config'; // @deprecated
+export { SparklineData } from './sparkline-chart/sparkline-chart-data'; // @deprecated

--- a/src/app/chart/sparkline-chart/index.ts
+++ b/src/app/chart/sparkline-chart/index.ts
@@ -2,7 +2,3 @@ export { SparklineChartComponent } from './sparkline-chart.component';
 export { SparklineChartConfig } from './sparkline-chart-config';
 export { SparklineChartData } from './sparkline-chart-data';
 export { SparklineChartModule } from './sparkline-chart.module';
-
-export { SparklineComponent } from './sparkline-chart.component'; // @deprecated Use SparklineChartComponent
-export { SparklineConfig } from './sparkline-chart-config'; // @deprecated Use SparklineChartConfig
-export { SparklineData } from './sparkline-chart-data'; // @deprecated Use SparklineChartData

--- a/src/app/chart/sparkline-chart/sparkline-chart-config.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart-config.ts
@@ -52,4 +52,9 @@ export class SparklineChartConfig extends ChartConfigBase {
 /**
  * @deprecated Use SparklineChartConfig
  */
-export class SparklineConfig extends SparklineChartConfig {}
+export class SparklineConfig extends SparklineChartConfig {
+  constructor() {
+    super();
+    console.log('patternfly-ng: SparklineConfig is deprecated; use SparklineChartConfig');
+  }
+}

--- a/src/app/chart/sparkline-chart/sparkline-chart-data.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart-data.ts
@@ -26,4 +26,9 @@ export abstract class SparklineChartData {
 /**
  * @deprecated Use SparklineChartData
  */
-export abstract class SparklineData extends SparklineChartData {}
+export abstract class SparklineData extends SparklineChartData {
+  constructor() {
+    super();
+    console.log('patternfly-ng: SparklineData is deprecated; use SparklineChartData');
+  }
+}

--- a/src/app/chart/sparkline-chart/sparkline-chart.component.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.component.ts
@@ -49,7 +49,7 @@ export class SparklineChartComponent extends ChartBase implements DoCheck, OnIni
    * Default constructor
    * @param chartDefaults
    */
-  constructor(private chartDefaults: ChartDefaults) {
+  constructor(protected chartDefaults: ChartDefaults) {
     super();
   }
 
@@ -244,4 +244,9 @@ export class SparklineChartComponent extends ChartBase implements DoCheck, OnIni
   selector: 'pfng-chart-sparkline',
   templateUrl: './sparkline-chart.component.html'
 })
-export class SparklineComponent extends SparklineChartComponent {}
+export class SparklineComponent extends SparklineChartComponent {
+  constructor(protected chartDefaults: ChartDefaults) {
+    super(chartDefaults);
+    console.log('patternfly-ng: SparklineComponent is deprecated; use SparklineChartComponent');
+  }
+}

--- a/src/app/chart/sparkline-chart/sparkline-chart.module.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { ChartDefaults } from '../chart-defaults';
-import { SparklineChartComponent } from './sparkline-chart.component';
+import { SparklineChartComponent, SparklineComponent } from './sparkline-chart.component';
 import { SparklineChartConfig } from './sparkline-chart-config';
 import { SparklineChartData } from './sparkline-chart-data';
 import { WindowReference } from '../../utilities/window.reference';
@@ -18,8 +18,8 @@ export {
     CommonModule,
     FormsModule
   ],
-  declarations: [SparklineChartComponent],
-  exports: [SparklineChartComponent],
+  declarations: [SparklineChartComponent, SparklineComponent],
+  exports: [SparklineChartComponent, SparklineComponent],
   providers: [ChartDefaults, WindowReference]
 })
 export class SparklineChartModule {}


### PR DESCRIPTION
Individual module imports for chart components.

This allows components to be imported individually without having to install an unused, optional dependency.

Deprecations

- ChartConfig: Use ChartConfigBase, DonutChartConfig, or SparklineChartConfig
- ChartModule: Use DonutChartModule and SparklineChartModule
- DonutConfig: Use DonutChartConfig or UtilizationDonutChartConfig
- SparklineComponent: Use SparklineChartComponent
- SparklineConfig: Use SparklineChartConfig
- SparklineData: Use SparklineChartData

Note: Backed out #377 to address a git commit issue with Travis. Adding code back in one module at a time.