### PR TITLE
Individual module imports for list components

### DIFF
--- a/src/app/list/basic-list/index.ts
+++ b/src/app/list/basic-list/index.ts
@@ -2,4 +2,3 @@ export { ListComponent } from './list.component';
 export { ListConfig } from './list-config';
 export { ListExpandToggleComponent } from './list-expand-toggle.component';
 export { ListModule } from './list.module';
-export { ListModule as BasicListModule  } from './list.module';

--- a/src/app/list/basic-list/list-config.ts
+++ b/src/app/list/basic-list/list-config.ts
@@ -1,9 +1,9 @@
-import { ListBaseConfig } from '../list-base-config';
+import { ListConfigBase } from '../list-config-base';
 
 /**
  * A config containing properties for list view
  */
-export class ListConfig extends ListBaseConfig {
+export class ListConfig extends ListConfigBase {
   /**
    * Set to true to hide the close button in the expansion area. Default is false
    */

--- a/src/app/list/basic-list/list.module.ts
+++ b/src/app/list/basic-list/list.module.ts
@@ -5,12 +5,13 @@ import { NgModule } from '@angular/core';
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { ListComponent } from './list.component';
 import { ListConfig } from './list-config';
+import { ListEvent } from '../list-event';
 import { ListExpandToggleComponent } from './list-expand-toggle.component';
 import { PipeModule } from '../../pipe/pipe.module';
 
 export {
   ListConfig,
-  ListExpandToggleComponent
+  ListEvent
 };
 
 /**

--- a/src/app/list/index.ts
+++ b/src/app/list/index.ts
@@ -1,5 +1,5 @@
 export { ListBase } from './list-base';
-export { ListBaseConfig } from './list-base-config';
+export { ListConfigBase } from './list-config-base';
 export { ListEvent } from './list-event';
 
 export * from './basic-list/index';

--- a/src/app/list/list-base.ts
+++ b/src/app/list/list-base.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 
 import { Action } from '../action/action';
-import { ListBaseConfig } from './list-base-config';
+import { ListConfigBase } from './list-config-base';
 import { ListEvent } from './list-event';
 
 /**
@@ -88,9 +88,9 @@ export abstract class ListBase {
   /**
    * Return component config
    *
-   * @returns {ListBaseConfig} The component config
+   * @returns {ListConfigBase} The component config
    */
-  protected abstract getConfig(): ListBaseConfig;
+  protected abstract getConfig(): ListConfigBase;
 
   // Accessors
 

--- a/src/app/list/list-config-base.ts
+++ b/src/app/list/list-config-base.ts
@@ -3,7 +3,7 @@ import { EmptyStateConfig } from '../empty-state/empty-state-config';
 /**
  * A config containing properties for tree list
  */
-export class ListBaseConfig {
+export class ListConfigBase {
   /**
    * Handle double clicking (item remains selected on a double click). Default is false
    */

--- a/src/app/list/list.module.ts
+++ b/src/app/list/list.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { ListBase } from './list-base';
-import { ListBaseConfig } from './list-base-config';
+import { ListConfigBase } from './list-config-base';
 import { ListEvent } from './list-event';
 import { ListComponent } from './basic-list/list.component';
 import { ListModule as BasicListModule } from './basic-list/list.module';
@@ -15,7 +15,7 @@ import { TreeListModule } from './tree-list/tree-list.module';
 
 export {
   ListBase,
-  ListBaseConfig,
+  ListConfigBase,
   ListConfig,
   ListEvent,
   TreeListConfig
@@ -24,7 +24,12 @@ export {
 /**
  * A module containing objects associated with list components
  *
- * @deprecated Use BasicListModule or TreeListModule
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   ListModule, // basic list only
+ *   TreeListModule
+ * } from 'patternfly-ng/list';
  */
 @NgModule({
   imports: [
@@ -35,4 +40,8 @@ export {
   ],
   exports: [ListComponent, ListExpandToggleComponent, TreeListComponent]
 })
-export class ListModule {}
+export class ListModule {
+  constructor() {
+    console.log('patternfly-ng: ListModule is deprecated; use TreeListModule and ListModule for basic list only');
+  }
+}

--- a/src/app/list/tree-list/tree-list-config.ts
+++ b/src/app/list/tree-list/tree-list-config.ts
@@ -1,9 +1,9 @@
-import { ListBaseConfig } from '../list-base-config';
+import { ListConfigBase } from '../list-config-base';
 
 /**
  * A config containing properties for tree list
  */
-export class TreeListConfig extends ListBaseConfig {
+export class TreeListConfig extends ListConfigBase {
   /**
    * Indent children by the given value in pixels
    */

--- a/src/app/list/tree-list/tree-list.module.ts
+++ b/src/app/list/tree-list/tree-list.module.ts
@@ -2,12 +2,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { EmptyStateModule } from '../../empty-state/empty-state.module';
-import { TreeListComponent } from './tree-list.component';
-import { TreeListConfig } from './tree-list-config';
 import { TreeModule } from 'angular-tree-component';
 
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { ListEvent } from '../list-event';
+import { TreeListComponent } from './tree-list.component';
+import { TreeListConfig } from './tree-list-config';
+
 export {
+  ListEvent,
   TreeListConfig
 };
 


### PR DESCRIPTION
Individual module imports for list components.

This allows components to be imported individually without having to install an unused, optional dependency.

Deprecations

- ListModule: Use TreeListModule and ListModule for basic list only

Note: Backed out #377 to address a git commit issue with Travis. Adding code back in one module at a time.