### PR TITLE
Individual module imports for notification components

### DIFF
--- a/src/app/notification/index.ts
+++ b/src/app/notification/index.ts
@@ -1,10 +1,11 @@
-export { InlineNotificationComponent } from './inline-notification/inline-notification.component';
 export { Notification } from './notification';
-export { NotificationDrawerComponent  } from './notification-drawer/notification-drawer.component';
 export { NotificationEvent } from './notification-event';
 export { NotificaitonGroup } from './notification-group';
-export { NotificationModule } from './notification.module';
+export { NotificationModule } from './notification.module'; // @deprecated
 export { NotificationType } from './notification-type';
-export { NotificationService } from './notification-service/notification.service';
-export { ToastNotificationComponent } from './toast-notification/toast-notification.component';
-export { ToastNotificationListComponent } from './toast-notification-list/toast-notification-list.component';
+
+export * from './inline-notification/index';
+export * from './notification-drawer/index';
+export * from './notification-service/index';
+export * from './toast-notification/index';
+export * from './toast-notification-list/index';

--- a/src/app/notification/inline-notification/example/inline-notification-example.module.ts
+++ b/src/app/notification/inline-notification/example/inline-notification-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { InlineNotificationExampleComponent } from './inline-notification-example.component';
+import { InlineNotificationModule } from '../inline-notification.module';
 
 @NgModule({
   declarations: [
@@ -18,7 +18,7 @@ import { InlineNotificationExampleComponent } from './inline-notification-exampl
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
+    InlineNotificationModule,
     TabsModule.forRoot()
   ],
   providers: [

--- a/src/app/notification/inline-notification/index.ts
+++ b/src/app/notification/inline-notification/index.ts
@@ -1,0 +1,2 @@
+export { InlineNotificationComponent } from './inline-notification.component';
+export { InlineNotificationModule } from './inline-notification.module';

--- a/src/app/notification/inline-notification/inline-notification.module.ts
+++ b/src/app/notification/inline-notification/inline-notification.module.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { InlineNotificationComponent } from './inline-notification.component';
+import { NotificationType } from '../notification-type';
+
+export {
+  NotificationType
+};
+
+/**
+ * A module containing objects associated with inline notifications
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    InlineNotificationComponent
+  ],
+  exports: [
+    InlineNotificationComponent
+  ]
+})
+export class InlineNotificationModule {}

--- a/src/app/notification/notification-drawer/example/notification-drawer-example.module.ts
+++ b/src/app/notification/notification-drawer/example/notification-drawer-example.module.ts
@@ -4,8 +4,8 @@ import { NgModule } from '@angular/core';
 
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
-import { NotificationModule } from '../../notification.module';
 import { NotificationDrawerExampleComponent } from './notification-drawer-example.component';
+import { NotificationDrawerModule } from '../notification-drawer.module';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
 import { ActionModule } from '../../../action/action.module';
 
@@ -15,11 +15,11 @@ import { ActionModule } from '../../../action/action.module';
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
+    NotificationDrawerModule,
     TabsModule.forRoot()
   ],
-  declarations: [ NotificationDrawerExampleComponent ],
-  providers: [ TabsetConfig ]
+  declarations: [NotificationDrawerExampleComponent],
+  providers: [TabsetConfig]
 })
 export class NotificationDrawerExampleModule {
   constructor() {}

--- a/src/app/notification/notification-drawer/index.ts
+++ b/src/app/notification/notification-drawer/index.ts
@@ -1,0 +1,2 @@
+export { NotificationDrawerComponent } from './notification-drawer.component';
+export { NotificationDrawerModule } from './notification-drawer.module';

--- a/src/app/notification/notification-drawer/notification-drawer.module.ts
+++ b/src/app/notification/notification-drawer/notification-drawer.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { NotificationDrawerComponent } from './notification-drawer.component';
+import { NotificaitonGroup } from '../notification-group';
+
+export {
+  NotificaitonGroup
+};
+
+/**
+ * A module containing objects associated with the notification drawer
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    EmptyStateModule,
+    FormsModule
+  ],
+  declarations: [
+    NotificationDrawerComponent
+  ],
+  exports: [
+    NotificationDrawerComponent
+  ]
+})
+export class NotificationDrawerModule {}

--- a/src/app/notification/notification-service/example/notification-service-example.module.ts
+++ b/src/app/notification/notification-service/example/notification-service-example.module.ts
@@ -6,11 +6,11 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { NotificationService } from '../notification.service';
 import { NotificationServiceExampleComponent } from './notification-service-example.component';
 import { NotificationServiceBasicExampleComponent } from './notification-service-basic-example.component';
 import { NotificationServiceObserverExampleComponent } from './notification-service-observer-example.component';
+import { ToastNotificationListModule } from '../../toast-notification-list';
 
 @NgModule({
   declarations: [
@@ -23,8 +23,8 @@ import { NotificationServiceObserverExampleComponent } from './notification-serv
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    ToastNotificationListModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/notification-service/index.ts
+++ b/src/app/notification/notification-service/index.ts
@@ -1,0 +1,1 @@
+export { NotificationService } from './notification.service';

--- a/src/app/notification/notification.module.ts
+++ b/src/app/notification/notification.module.ts
@@ -1,16 +1,18 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { InlineNotificationComponent } from './inline-notification/inline-notification.component';
+import { InlineNotificationModule } from './inline-notification/inline-notification.module';
+import { NotificationDrawerComponent } from './notification-drawer/notification-drawer.component';
+import { NotificationDrawerModule } from './notification-drawer/notification-drawer.module';
 import { NotificaitonGroup } from './notification-group';
 import { NotificationEvent } from './notification-event';
 import { NotificationType } from './notification-type';
-import { NotificationService } from './notification-service/notification.service';
 import { ToastNotificationComponent } from './toast-notification/toast-notification.component';
+import { ToastNotificationModule } from './toast-notification/toast-notification.module';
 import { ToastNotificationListComponent } from './toast-notification-list/toast-notification-list.component';
-import { InlineNotificationComponent } from './inline-notification/inline-notification.component';
-import { NotificationDrawerComponent } from './notification-drawer/notification-drawer.component';
-import { EmptyStateModule } from '../empty-state/empty-state.module';
+import { ToastNotificationListModule } from './toast-notification-list/toast-notification-list.module';
 
 export {
   NotificationEvent,
@@ -20,13 +22,35 @@ export {
 
 /**
  * A module containing objects associated with notification components
+ *
+ * @deprecated Use individual module imports
+ *
+ * import {
+ *   InlineNotificationModule,
+ *   NotificationDrawerModule,
+ *   ToastNotificationModule,
+ *   ToastNotificationListModule
+ * } from 'patternfly-ng/notification';
  */
 @NgModule({
-  imports: [BsDropdownModule.forRoot(), CommonModule, EmptyStateModule],
-  declarations: [ToastNotificationComponent, ToastNotificationListComponent, InlineNotificationComponent, 
-    NotificationDrawerComponent],
-  exports: [ToastNotificationComponent, ToastNotificationListComponent, InlineNotificationComponent, 
-    NotificationDrawerComponent],
-  providers: [BsDropdownConfig, NotificationService]
+  imports: [
+    CommonModule,
+    FormsModule,
+    InlineNotificationModule,
+    NotificationDrawerModule,
+    ToastNotificationModule,
+    ToastNotificationListModule
+  ],
+  exports: [
+    InlineNotificationComponent,
+    NotificationDrawerComponent,
+    ToastNotificationComponent,
+    ToastNotificationListComponent
+  ]
 })
-export class NotificationModule {}
+export class NotificationModule {
+  constructor() {
+    console.log('patternfly-ng: NotificationModule is deprecated; use InlineNotificationModule, ' +
+      'NotificationDrawerModule, ToastNotificationModule, or ToastNotificationListModule');
+  }
+}

--- a/src/app/notification/toast-notification-list/example/toast-notification-list-example.module.ts
+++ b/src/app/notification/toast-notification-list/example/toast-notification-list-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { ToastNotificationListExampleComponent } from './toast-notification-list-example.component';
+import { ToastNotificationListModule } from '../toast-notification-list.module';
 
 @NgModule({
   declarations: [
@@ -18,8 +18,8 @@ import { ToastNotificationListExampleComponent } from './toast-notification-list
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    ToastNotificationListModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/toast-notification-list/index.ts
+++ b/src/app/notification/toast-notification-list/index.ts
@@ -1,0 +1,2 @@
+export { ToastNotificationListComponent } from './toast-notification-list.component';
+export { ToastNotificationListModule } from './toast-notification-list.module';

--- a/src/app/notification/toast-notification-list/toast-notification-list.module.ts
+++ b/src/app/notification/toast-notification-list/toast-notification-list.module.ts
@@ -1,0 +1,31 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { Notification } from '../notification';
+import { NotificationEvent } from '../notification-event';
+import { ToastNotificationListComponent } from './toast-notification-list.component';
+import { ToastNotificationModule } from '../toast-notification';
+
+export {
+  Notification,
+  NotificationEvent
+};
+
+/**
+ * A module containing objects associated with toast notification lists
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ToastNotificationModule
+  ],
+  declarations: [
+    ToastNotificationListComponent
+  ],
+  exports: [
+    ToastNotificationListComponent
+  ]
+})
+export class ToastNotificationListModule {}

--- a/src/app/notification/toast-notification/example/toast-notification-example.module.ts
+++ b/src/app/notification/toast-notification/example/toast-notification-example.module.ts
@@ -6,8 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { NotificationModule } from '../../notification.module';
 import { ToastNotificationExampleComponent } from './toast-notification-example.component';
+import { ToastNotificationModule } from '../toast-notification.module';
 
 @NgModule({
   declarations: [
@@ -18,8 +18,8 @@ import { ToastNotificationExampleComponent } from './toast-notification-example.
     CommonModule,
     DemoComponentsModule,
     FormsModule,
-    NotificationModule,
-    TabsModule.forRoot()
+    TabsModule.forRoot(),
+    ToastNotificationModule
   ],
   providers: [
     BsDropdownConfig,

--- a/src/app/notification/toast-notification/index.ts
+++ b/src/app/notification/toast-notification/index.ts
@@ -1,0 +1,2 @@
+export { ToastNotificationComponent } from './toast-notification.component';
+export { ToastNotificationModule } from './toast-notification.module';

--- a/src/app/notification/toast-notification/toast-notification.module.ts
+++ b/src/app/notification/toast-notification/toast-notification.module.ts
@@ -1,0 +1,35 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+
+import { Notification } from '../notification';
+import { NotificationEvent } from '../notification-event';
+import { ToastNotificationComponent } from './toast-notification.component';
+
+export {
+  Notification,
+  NotificationEvent
+};
+
+/**
+ * A module containing objects associated with toast notifications
+ */
+@NgModule({
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    ToastNotificationComponent
+  ],
+  exports: [
+    ToastNotificationComponent
+  ],
+  providers: [
+    BsDropdownConfig
+  ]
+})
+export class ToastNotificationModule {}

--- a/src/app/patternfly-ng.module.ts
+++ b/src/app/patternfly-ng.module.ts
@@ -4,15 +4,15 @@ import { FormsModule } from '@angular/forms';
 import {
   ActionModule,
   CardModule,
-  ChartModule,
+  ChartModule, // @deprecated
   EmptyStateModule,
   FilterModule,
   ListModule,
   ModalModule,
-  NavigationModule,
-  NotificationModule,
+  NavigationModule, // @deprecated
+  NotificationModule, // @deprecated
   PaginationModule,
-  PipeModule,
+  PipeModule, // @deprecated
   RemainingCharsCountModule,
   SampleModule,
   SortModule,
@@ -31,16 +31,16 @@ import {
   exports: [
     ActionModule,
     CardModule,
-    ChartModule,
+    ChartModule, // @deprecated
     EmptyStateModule,
     FilterModule,
     ListModule,
     ModalModule,
-    NavigationModule,
-    NotificationModule,
+    NavigationModule, // @deprecated
+    NotificationModule, // @deprecated
     PaginationModule,
     RemainingCharsCountModule,
-    PipeModule,
+    PipeModule, // @deprecated
     SampleModule,
     SortModule,
     TableModule,


### PR DESCRIPTION
Individual module imports for notification components.

This allows components to be imported individually without having to install an unused, optional dependency.

Deprecations

- NotificationModule: Use InlineNotificationModule, NotificationDrawerModule, NotificationServiceModule, ToastNotificationModule, or ToastNotificationListModule

Note: Backed out #377 to address a git commit issue with Travis. Adding code back in one module at a time.