### PR TITLE
Individual module imports for table components

### DIFF
--- a/src/app/table/basic-table/example/table-example.module.ts
+++ b/src/app/table/basic-table/example/table-example.module.ts
@@ -16,7 +16,7 @@ import { TableExpansionExampleComponent } from './table-expansion-example.compon
 import { TableGroupExampleComponent } from './table-group-example.component';
 import { TableViewExampleComponent } from './table-view-example.component';
 import { DemoComponentsModule } from '../../../../demo/components/demo-components.module';
-import { TableModule } from '../../table.module';
+import { TableModule } from '../table.module';
 import { ToolbarModule } from '../../../toolbar/toolbar.module';
 
 @NgModule({

--- a/src/app/table/basic-table/index.ts
+++ b/src/app/table/basic-table/index.ts
@@ -1,0 +1,5 @@
+export { NgxDataTableConfig } from './ngx-datatable-config';
+export { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
+export { TableComponent } from './table.component';
+export { TableConfig } from './table-config';
+export { TableModule } from './table.module';

--- a/src/app/table/basic-table/table.module.ts
+++ b/src/app/table/basic-table/table.module.ts
@@ -5,22 +5,18 @@ import { FormsModule } from '@angular/forms';
 import { DragulaModule, DragulaService } from 'ng2-dragula';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
-import { PaginationModule } from '../pagination/pagination.module';
-import { EmptyStateModule } from '../empty-state/empty-state.module';
-import { NgxDataTableConfig } from './basic-table/ngx-datatable-config';
-import { NgxDataTableDndDirective } from './basic-table/ngx-datatable-dnd.directive';
-import { TableBase } from './table-base';
-import { TableComponent } from './basic-table/table.component';
-import { TableConfig } from './basic-table/table-config';
-import { TableConfigBase } from './table-config-base';
-import { TableEvent } from './table-event';
-import { ToolbarModule } from '../toolbar/toolbar.module';
+import { PaginationModule } from '../../pagination/pagination.module';
+import { EmptyStateModule } from '../../empty-state/empty-state.module';
+import { NgxDataTableConfig } from './ngx-datatable-config';
+import { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
+import { TableComponent } from './table.component';
+import { TableConfig } from './table-config';
+import { TableEvent } from '../table-event';
+import { ToolbarModule } from '../../toolbar/toolbar.module';
 
 export {
   NgxDataTableConfig,
-  TableBase,
   TableConfig,
-  TableConfigBase,
   TableEvent
 };
 

--- a/src/app/table/index.ts
+++ b/src/app/table/index.ts
@@ -1,8 +1,5 @@
-export { NgxDataTableConfig } from './basic-table/ngx-datatable-config';
-export { NgxDataTableDndDirective } from './basic-table/ngx-datatable-dnd.directive';
 export { TableBase } from './table-base';
-export { TableComponent } from './basic-table/table.component';
-export { TableConfig } from './basic-table/table-config';
 export { TableConfigBase } from './table-config-base';
 export { TableEvent } from './table-event';
-export { TableModule } from './table.module';
+
+export * from './basic-table/index';


### PR DESCRIPTION
Individual module imports for table components.

This allows components to be imported individually without having to install an unused, optional dependency.

Note: Backed out #377 to address a git commit issue with Travis. Adding code back in one module at a time.