### PR TITLE
Bump patternfly-eng-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "nsp": "2.7.0",
     "optimize-js-plugin": "0.0.4",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "3.26.54",
+    "patternfly-eng-release": "^3.26.64",
     "phantomjs-prebuilt": "2.1.14",
     "protractor": "5.1.1",
     "raw-loader": "0.5.1",


### PR DESCRIPTION
Bump patternfly-eng-release version to use separate `git commits` for dist and dist-demo due to Travis memory issue.