### PR TITLE
Module cleanup

### DIFF
--- a/src/app/card/basic-card/card.module.ts
+++ b/src/app/card/basic-card/card.module.ts
@@ -2,20 +2,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { CardAction } from '../card-action/card-action';
 import { CardActionModule } from '../card-action/card-action.module';
 import { CardComponent } from '../basic-card/card.component';
-import { CardConfig } from '../basic-card/card-config';
-import { CardFilter } from '../card-filter/card-filter';
 import { CardFilterModule } from '../card-filter/card-filter.module';
-import { CardFilterPosition } from '../card-filter/card-filter-position';
-
-export {
-  CardAction,
-  CardConfig,
-  CardFilter,
-  CardFilterPosition
-};
 
 /**
  * A module containing objects associated with basic card components

--- a/src/app/card/card-action/card-action.module.ts
+++ b/src/app/card/card-action/card-action.module.ts
@@ -2,12 +2,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { CardAction } from './card-action';
 import { CardActionComponent } from './card-action.component';
-
-export {
-  CardAction
-};
 
 /**
  * A module containing objects associated with card action components

--- a/src/app/card/card-filter/card-filter.module.ts
+++ b/src/app/card/card-filter/card-filter.module.ts
@@ -4,14 +4,7 @@ import { NgModule } from '@angular/core';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
-import { CardFilter } from './card-filter';
 import { CardFilterComponent } from './card-filter.component';
-import { CardFilterPosition } from './card-filter-position';
-
-export {
-  CardFilter,
-  CardFilterPosition
-};
 
 /**
  * A module containing objects associated with card filter components

--- a/src/app/card/info-status-card/info-status-card.module.ts
+++ b/src/app/card/info-status-card/info-status-card.module.ts
@@ -2,12 +2,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { InfoStatusCardConfig } from './info-status-card-config';
 import { InfoStatusCardComponent } from './info-status-card.component';
-
-export {
-  InfoStatusCardConfig
-};
 
 /**
  * A module containing objects associated with info status card components

--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.module.ts
@@ -4,14 +4,8 @@ import { NgModule } from '@angular/core';
 
 import { ChartDefaults } from '../../chart-defaults';
 
-import { DonutChartConfig } from './donut-chart-config';
 import { DonutChartComponent, DonutComponent } from './donut-chart.component';
 import { WindowReference } from '../../../utilities/window.reference';
-
-export {
-  ChartDefaults,
-  DonutChartConfig,
-};
 
 @NgModule({
   imports: [

--- a/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
+++ b/src/app/chart/donut-chart/utilization-donut-chart/utilization-donut-chart.module.ts
@@ -4,13 +4,7 @@ import { NgModule } from '@angular/core';
 
 import { ChartDefaults } from '../../chart-defaults';
 import { UtilizationDonutChartComponent } from './utilization-donut-chart.component';
-import { UtilizationDonutChartConfig } from './utilization-donut-chart-config';
 import { WindowReference } from '../../../utilities/window.reference';
-
-export {
-  ChartDefaults,
-  UtilizationDonutChartConfig,
-};
 
 @NgModule({
   imports: [

--- a/src/app/chart/sparkline-chart/sparkline-chart.module.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.module.ts
@@ -4,14 +4,7 @@ import { NgModule } from '@angular/core';
 
 import { ChartDefaults } from '../chart-defaults';
 import { SparklineChartComponent, SparklineComponent } from './sparkline-chart.component';
-import { SparklineChartConfig } from './sparkline-chart-config';
-import { SparklineChartData } from './sparkline-chart-data';
 import { WindowReference } from '../../utilities/window.reference';
-
-export {
-  SparklineChartConfig,
-  SparklineChartData
-};
 
 @NgModule({
   imports: [

--- a/src/app/list/basic-list/list.module.ts
+++ b/src/app/list/basic-list/list.module.ts
@@ -4,15 +4,8 @@ import { NgModule } from '@angular/core';
 
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { ListComponent } from './list.component';
-import { ListConfig } from './list-config';
-import { ListEvent } from '../list-event';
 import { ListExpandToggleComponent } from './list-expand-toggle.component';
 import { SortArrayPipeModule } from '../../pipe/sort-array/sort-array.pipe.module';
-
-export {
-  ListConfig,
-  ListEvent
-};
 
 /**
  * A module containing objects associated with basic list components

--- a/src/app/list/tree-list/tree-list.module.ts
+++ b/src/app/list/tree-list/tree-list.module.ts
@@ -5,14 +5,7 @@ import { NgModule } from '@angular/core';
 import { TreeModule } from 'angular-tree-component';
 
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
-import { ListEvent } from '../list-event';
 import { TreeListComponent } from './tree-list.component';
-import { TreeListConfig } from './tree-list-config';
-
-export {
-  ListEvent,
-  TreeListConfig
-};
 
 /**
  * A module containing objects associated with tree list components

--- a/src/app/notification/inline-notification/inline-notification.module.ts
+++ b/src/app/notification/inline-notification/inline-notification.module.ts
@@ -3,11 +3,6 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { InlineNotificationComponent } from './inline-notification.component';
-import { NotificationType } from '../notification-type';
-
-export {
-  NotificationType
-};
 
 /**
  * A module containing objects associated with inline notifications

--- a/src/app/notification/notification-drawer/notification-drawer.module.ts
+++ b/src/app/notification/notification-drawer/notification-drawer.module.ts
@@ -4,11 +4,6 @@ import { NgModule } from '@angular/core';
 
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
 import { NotificationDrawerComponent } from './notification-drawer.component';
-import { NotificaitonGroup } from '../notification-group';
-
-export {
-  NotificaitonGroup
-};
 
 /**
  * A module containing objects associated with the notification drawer

--- a/src/app/notification/toast-notification-list/toast-notification-list.module.ts
+++ b/src/app/notification/toast-notification-list/toast-notification-list.module.ts
@@ -2,15 +2,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
-import { Notification } from '../notification';
-import { NotificationEvent } from '../notification-event';
 import { ToastNotificationListComponent } from './toast-notification-list.component';
 import { ToastNotificationModule } from '../toast-notification';
-
-export {
-  Notification,
-  NotificationEvent
-};
 
 /**
  * A module containing objects associated with toast notification lists

--- a/src/app/notification/toast-notification/toast-notification.module.ts
+++ b/src/app/notification/toast-notification/toast-notification.module.ts
@@ -4,14 +4,7 @@ import { NgModule } from '@angular/core';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
-import { Notification } from '../notification';
-import { NotificationEvent } from '../notification-event';
 import { ToastNotificationComponent } from './toast-notification.component';
-
-export {
-  Notification,
-  NotificationEvent
-};
 
 /**
  * A module containing objects associated with toast notifications

--- a/src/app/table/basic-table/index.ts
+++ b/src/app/table/basic-table/index.ts
@@ -1,5 +1,4 @@
 export { NgxDataTableConfig } from './ngx-datatable-config';
-export { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
 export { TableComponent } from './table.component';
 export { TableConfig } from './table-config';
 export { TableModule } from './table.module';

--- a/src/app/table/basic-table/table.module.ts
+++ b/src/app/table/basic-table/table.module.ts
@@ -7,18 +7,9 @@ import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { PaginationModule } from '../../pagination/pagination.module';
 import { EmptyStateModule } from '../../empty-state/empty-state.module';
-import { NgxDataTableConfig } from './ngx-datatable-config';
 import { NgxDataTableDndDirective } from './ngx-datatable-dnd.directive';
 import { TableComponent } from './table.component';
-import { TableConfig } from './table-config';
-import { TableEvent } from '../table-event';
 import { ToolbarModule } from '../../toolbar/toolbar.module';
-
-export {
-  NgxDataTableConfig,
-  TableConfig,
-  TableEvent
-};
 
 /**
  * A module containing objects associated with table components


### PR DESCRIPTION
Remove unnecessary exports from new modules. The same objects are already exported via index files