### PR TITLE
Utilities import should have its own index file

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -14,5 +14,5 @@ export * from './sample/index';
 export * from './sort/index';
 export * from './table/index';
 export * from './toolbar/index';
-export * from './utilities/window.reference';
+export * from './utilities/index';
 export * from './wizard/index';

--- a/src/app/utilities/index.ts
+++ b/src/app/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './window.reference';


### PR DESCRIPTION
This simply adds an index file to export the window reference utility