### PR TITLE
vertical-nav: close secondary and tertiary menus upon leaf node click

### DIFF
--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
@@ -697,10 +697,9 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
 
   private navigateToItem(item: VerticalNavigationItem): void {
     let navItem = this.getFirstNavigateChild(item);
-    let navTo;
     if (navItem) {
       this._showMobileNav = false;
-      navTo = navItem.url;
+      let navTo = navItem.url;
       if (navTo) {
         this.router.navigateByUrl(navTo);
       }
@@ -709,17 +708,32 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (this.itemClickEvent) {
-      this.itemClickEvent.emit(item);
-    }
-
     if (this.updateActiveItemsOnClick) {
       this.clearActiveItems();
       navItem.trackActiveState = true;
       this.setParentActive(navItem);
+    }
+
+    // Dismiss items (leaf nodes) immediately upon click
+    if (!item.children) {
+      this._hoverSecondaryNav = false;
+      this._hoverTertiaryNav = false;
+      this.items.forEach((primary) => {
+        if (!this.persistentSecondary) {
+          primary.trackHoverState = false;
+        }
+        if (primary.children !== undefined) {
+          primary.children.forEach((secondary) => {
+            if (!this.persistentSecondary) {
+              secondary.trackHoverState = false;
+            }
+          });
+        }
+      });
+    } else {
       this.setSecondaryItemVisible();
     }
-    this.setSecondaryItemVisible();
+    this.itemClickEvent.emit(item);
   }
 
   private primaryHover(): boolean {


### PR DESCRIPTION
This change closes the secondary and tertiary menus upon leaf node click. Otherwise, the user must hover or click outside the navigation area, then wait a couple seconds for the menu to dismiss.

Fixes https://github.com/patternfly/patternfly-ng/issues/372

FYI @ssilvert