### PR TITLE
applies font awesome's fixed-width class to the 'angle' icon in the basic list component

### DIFF
--- a/src/app/list/basic-list/list-expand-toggle.component.html
+++ b/src/app/list/basic-list/list-expand-toggle.component.html
@@ -1,5 +1,5 @@
 <div class="list-pf-chevron" (click)="toggleExpand()">
-  <span class="fa fa-angle-right" [ngClass]="{'fa-angle-down': isExpanded}"></span>
+  <span class="fa fa-fw fa-angle-right" [ngClass]="{'fa-angle-down': isExpanded}"></span>
   <ng-template *ngIf="template" let-item="item"
                [ngTemplateOutlet]="template"
                [ngTemplateOutletContext]="{ item: item }"></ng-template>


### PR DESCRIPTION
https://fontawesome.com/v4.7.0/examples/#fixed-width

This makes the font awesome icons a uniform width, so when the icon changes from `angle-right` to `angle-down` the adjacent label doesn't shift position.