### PR TITLE
copy: bad DOCUMENT inject broke all module imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "module": "index.js",
   "typings": "index.d.ts",
   "scripts": {
-    "build": "npm-run-all --serial remove-dist ts:lint build:bundle build:demo copy-examples:demo",
-    "build:bundle": "npm-run-all build:library build:es2015 build:umd build:umd-uglify",
+    "build": "npm-run-all --serial ts:lint build:bundle build:demo copy-examples:demo",
+    "build:bundle": "npm-run-all remove-dist build:library build:es2015 build:umd build:umd-uglify",
     "build:demo": "webpack --config config/webpack.demo.js --progress --profile --bail",
     "build:es2015": "rollup --config src/scripts/bundle/es2015.config.js",
     "build:library": "gulp build",

--- a/src/app/copy/block-copy/block-copy.component.ts
+++ b/src/app/copy/block-copy/block-copy.component.ts
@@ -21,8 +21,7 @@ import { CopyService } from '../copy-service/copy.service';
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'pfng-block-copy',
-  templateUrl: './block-copy.component.html',
-  styleUrls: ['./block-copy.component.less']
+  templateUrl: './block-copy.component.html'
 })
 export class BlockCopyComponent extends CopyBase {
   /**

--- a/src/app/copy/copy-base.ts
+++ b/src/app/copy/copy-base.ts
@@ -34,7 +34,7 @@ export abstract class CopyBase {
   /**
    * Event emitted when values are copied to the clipboard
    */
-  @Output('onCopy') onCopy: EventEmitter<CopyEvent> = new EventEmitter();
+  @Output('onCopy') onCopy = new EventEmitter();
 
   private _recentlyCopied: boolean = false;
 

--- a/src/app/copy/copy-event.ts
+++ b/src/app/copy/copy-event.ts
@@ -1,7 +1,7 @@
 /**
  * An object containing properties for copy events
  */
-export interface CopyEvent {
+export class CopyEvent {
   /**
    * The copied value
    */

--- a/src/app/copy/copy-service/copy.service.ts
+++ b/src/app/copy/copy-service/copy.service.ts
@@ -15,15 +15,12 @@ import { DOCUMENT } from '@angular/common';
  */
 @Injectable()
 export class CopyService {
-  public dom: Document;
   private verbose: boolean = false;
 
   /**
    * The default constructor
    */
-  constructor(@Inject(DOCUMENT) dom: Document) {
-    this.dom = dom;
-  }
+  constructor(@Inject(DOCUMENT) private dom: any) {}
 
   /**
    * Copy a value to the user's system clipboard

--- a/src/app/copy/index.ts
+++ b/src/app/copy/index.ts
@@ -4,4 +4,3 @@ export { CopyEvent } from './copy-event';
 export * from './block-copy/index';
 export * from './copy-service/index';
 export * from './inline-copy/index';
-

--- a/src/app/copy/inline-copy/inline-copy.component.ts
+++ b/src/app/copy/inline-copy/inline-copy.component.ts
@@ -18,8 +18,7 @@ import { CopyService } from '../copy-service/copy.service';
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'pfng-inline-copy',
-  templateUrl: './inline-copy.component.html',
-  styleUrls: ['./inline-copy.component.less']
+  templateUrl: './inline-copy.component.html'
 })
 export class InlineCopyComponent extends CopyBase {
   /**

--- a/src/assets/stylesheets/patternfly-ng.less
+++ b/src/assets/stylesheets/patternfly-ng.less
@@ -4,6 +4,8 @@
 
 @import '../../app/card/basic-card/card.component.less';
 @import '../../app/card/info-status-card/info-status-card.component.less';
+@import '../../app/copy/block-copy/block-copy.component.less';
+@import '../../app/copy/inline-copy/inline-copy.component.less';
 @import '../../app/empty-state/empty-state.component.less';
 @import '../../app/filter/filter.component.less';
 @import '../../app/filter/filter-fields.component.less';


### PR DESCRIPTION
It appears that the new copy service has a bad DOCUMENT injection. Unfortunately, this breaks all module imports. 

In addition, I discovered that the copy component's CSS is not included correctly. The component's CSS should be included via the patternfly-ng stylesheet, not via the component's styleUrls property. That allows applications to override the CSS generated by patternfly-ng.

Fixes https://github.com/patternfly/patternfly-ng/issues/402