### PR TITLE
copy: add dom accessor for unit test

### DIFF
--- a/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.spec.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/donut-chart.component.spec.ts
@@ -12,7 +12,7 @@ import { DonutChartConfig } from './donut-chart-config';
 import { DonutChartComponent } from './donut-chart.component';
 import { WindowReference } from '../../../utilities/window.reference';
 
-describe('Component: donut chart', () => {
+describe('Donut Chart component', () => {
   let comp: DonutChartComponent;
   let fixture: ComponentFixture<DonutChartComponent>;
 

--- a/src/app/chart/sparkline-chart/sparkline-chart.component.spec.ts
+++ b/src/app/chart/sparkline-chart/sparkline-chart.component.spec.ts
@@ -12,7 +12,7 @@ import { SparklineChartComponent } from './sparkline-chart.component';
 import { SparklineChartConfig } from './sparkline-chart-config';
 import { SparklineChartData } from './sparkline-chart-data';
 
-describe('Component: sparkline chart', () => {
+describe('Sparkline Chart component', () => {
   let comp: SparklineChartComponent;
   let fixture: ComponentFixture<SparklineChartComponent>;
 

--- a/src/app/copy/block-copy/block-copy.component.spec.ts
+++ b/src/app/copy/block-copy/block-copy.component.spec.ts
@@ -12,7 +12,7 @@ import { BlockCopyComponent } from './block-copy.component';
 
 class MockedCopyService {}
 
-describe('Block Copy Component - ', () => {
+describe('Block Copy component', () => {
 
   let blockCopy: BlockCopyComponent;
   let fixture: ComponentFixture<BlockCopyComponent>;

--- a/src/app/copy/copy-service/copy.service.ts
+++ b/src/app/copy/copy-service/copy.service.ts
@@ -20,7 +20,16 @@ export class CopyService {
   /**
    * The default constructor
    */
-  constructor(@Inject(DOCUMENT) private dom: any) {}
+  constructor(@Inject(DOCUMENT) private _dom: any) {}
+
+  /**
+   * Accessor for testing purposes only
+   *
+   * @returns {any}
+   */
+  get dom(): any {
+    return this._dom;
+  }
 
   /**
    * Copy a value to the user's system clipboard

--- a/src/app/copy/inline-copy/inline-copy.component.spec.ts
+++ b/src/app/copy/inline-copy/inline-copy.component.spec.ts
@@ -16,7 +16,7 @@ class MockedCopyService {
   }
 }
 
-describe('Inline Copy Component - ', () => {
+describe('Inline Copy component - ', () => {
 
   let inlineCopy: InlineCopyComponent;
   let fixture: ComponentFixture<InlineCopyComponent>;

--- a/src/app/empty-state/empty-state.component.spec.ts
+++ b/src/app/empty-state/empty-state.component.spec.ts
@@ -9,7 +9,7 @@ import { FormsModule } from '@angular/forms';
 import { EmptyStateComponent } from './empty-state.component';
 import { EmptyStateConfig } from './empty-state-config';
 
-describe('Empty state component - ', () => {
+describe('Empty State component - ', () => {
   let comp: EmptyStateComponent;
   let fixture: ComponentFixture<EmptyStateComponent>;
   let config: EmptyStateConfig;


### PR DESCRIPTION
Unit tests are generating warnings because the copy service spec references a private dom object.