### PR TITLE
Update sematic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -x
 
 after_success:
-  - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
-       npm run semantic-release-pre;
-       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh || travis_terminate 0;
-       npm run semantic-release-post;
-     fi'
   - npm run publish-travis
 
 branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13622,9 +13622,9 @@
       "dev": true
     },
     "patternfly-eng-release": {
-      "version": "3.26.73",
-      "resolved": "https://registry.npmjs.org/patternfly-eng-release/-/patternfly-eng-release-3.26.73.tgz",
-      "integrity": "sha512-nD3B+k8Rd0EAEgRSj5yK0qnEHl4B/k1SAkggyOz5LrAuFg+aUW+H8Vyc9WA+qHVHr4rWKURpYEKXycUvucpN4g==",
+      "version": "3.26.74",
+      "resolved": "https://registry.npmjs.org/patternfly-eng-release/-/patternfly-eng-release-3.26.74.tgz",
+      "integrity": "sha512-vkCnx1bDbpWdqQU3QOFSPmQu1ty09dL5qvgR3+fCKl5jUjozKW7kMnXLicDyWvHpnKvKIIHsDVMLYp0lh81a+A==",
       "dev": true
     },
     "pause-stream": {
@@ -16220,6 +16220,31 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+      "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.1"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
         }
       }
     },
@@ -19263,15 +19288,6 @@
             "ms": "2.0.0"
           }
         },
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": "0.7.0"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -19296,31 +19312,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "sockjs-client": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-          "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "eventsource": "0.1.6",
-            "faye-websocket": "0.11.1",
-            "inherits": "2.0.3",
-            "json3": "3.3.2",
-            "url-parse": "1.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "lint:less:fix": "npm run lint:less -- --fix",
     "lint:ts": "tslint -c tslint.json 'src/**/*.ts'",
     "lint:ts:fix": "npm run lint:ts -- --fix",
-    "postinstall": "node src/scripts/package/install.js",
     "publish-travis": "node_modules/patternfly-eng-publish/script/publish-ghpages.sh -t dist-demo",
     "reinstall": "npm run clean && npm install",
     "rimraf": "rimraf",
@@ -56,13 +55,38 @@
     "ng5",
     "ng6"
   ],
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/patternfly/patternfly-ng/issues"
+  },
   "homepage": "https://github.com/patternfly/patternfly-ng",
   "repository": {
     "type": "git",
     "url": "https://github.com/patternfly/patternfly-ng.git"
   },
-  "bugs": {
-    "url": "https://github.com/patternfly/patternfly-ng/issues"
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "tag": "latest"
+  },
+  "release": {
+    "branch": "master",
+    "prepare": [
+      {
+        "path": "@semantic-release/npm",
+        "pkgRoot": "dist"
+      }
+    ],
+    "publish": [
+      {
+        "path": "@semantic-release/npm",
+        "pkgRoot": "dist"
+      },
+      "@semantic-release/github"
+    ]
   },
   "engines": {
     "node": ">=8.11.1",
@@ -155,7 +179,7 @@
     "nsp": "3.2.1",
     "optimize-js-plugin": "0.0.4",
     "patternfly-eng-publish": "0.0.4",
-    "patternfly-eng-release": "^3.26.73",
+    "patternfly-eng-release": "^3.26.74",
     "phantomjs-prebuilt": "2.1.16",
     "protractor": "5.4.0",
     "raw-loader": "0.5.1",
@@ -188,19 +212,5 @@
     "webpack-dev-server": "3.1.5",
     "webpack-merge": "4.1.3",
     "zone.js": "0.8.26"
-  },
-  "release": {
-    "branch": "master-dist",
-    "debug": false,
-    "pkgRoot": "./dist"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
-  "files": [
-    "dist",
-    "src/scripts"
-  ]
+  }
 }


### PR DESCRIPTION
Update sematic release to v15.x. 

This also removes the master-dist build, since we're using gh-pages. Forked repos will continue to build master-dist for use with rawgit.