### PR TITLE
add disabled type for filter dropdown

### DIFF
--- a/src/app/filter/example/filter-basic-example.component.ts
+++ b/src/app/filter/example/filter-basic-example.component.ts
@@ -142,6 +142,11 @@ export class FilterBasicExampleComponent implements OnInit {
           id: 'day7',
           value: 'Saturday'
         }]
+      }, {
+        id: 'apples',
+        title: 'Apples',
+        placeholder: 'Filter by apples...',
+        type: FilterType.DISABLED
       }] as FilterField[],
       resultsCount: this.items.length,
       appliedFilters: []

--- a/src/app/filter/filter-fields.component.ts
+++ b/src/app/filter/filter-fields.component.ts
@@ -223,6 +223,9 @@ export class FilterFieldsComponent implements DoCheck, OnInit {
     if (field.type === undefined || field.type === 'text') {
       return false;
     }
+    if (field.type === 'disabled') {
+      return true;
+    }
     return (field.queries === undefined || field.queries.length === 0);
   }
 

--- a/src/app/filter/filter-type.ts
+++ b/src/app/filter/filter-type.ts
@@ -16,4 +16,10 @@ export class FilterType {
    * Type ahead type
    */
   static readonly TYPEAHEAD: string = 'typeahead';
+
+  /**
+   * Disabled type
+   */
+  static readonly DISABLED: string = 'disabled';
+
 }

--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -114,6 +114,11 @@ describe('Filter component - ', () => {
           id: 'day7',
           value: 'Saturday'
         }]
+      }, {
+        id: 'apples',
+        title: 'Apples',
+        placeholder: 'Filter by apples...',
+        type: FilterType.DISABLED
       }] as FilterField[],
       appliedFilters: [],
       resultsCount: 5
@@ -152,7 +157,19 @@ describe('Filter component - ', () => {
     fixture.detectChanges(); // Workaround to fix dropdown tests
 
     let fields = element.querySelectorAll('.filter-field');
-    expect(fields.length).toBe(5);
+    expect(fields.length).toBe(6);
+  }));
+
+  it('should have correct number of disabled filter fields', fakeAsync(function() {
+    const element = fixture.nativeElement;
+
+    let button = element.querySelector('.filter-pf button');
+    button.click();
+    tick();
+    fixture.detectChanges(); // Workaround to fix dropdown tests
+
+    let fields = element.querySelectorAll('.filter-pf .disabled');
+    expect(fields.length).toBe(1);
   }));
 
   it('should have correct number of results', function() {


### PR DESCRIPTION
This is good when a user wants to disable an option within the filter dropdown. It can be done by setting FilterField type value as FilterType.DISABLED