### PR TITLE
fix(tabs): ensure events are of appropriate type before setting tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "demo:webserver": "npm run webpack-dev-server -- --config config/webpack.demo.js --host 0.0.0.0 --port 8001 --progress --profile --hot --content-base dist-demo",
     "lint:less": "stylelint 'src/**/*.less' --config .stylelintrc",
     "lint:less:fix": "npm run lint:less -- --fix",
-    "lint:ts": "tslint -c tslint.json 'src/**/*.ts'",
+    "lint:ts": "tslint -c tslint.json --project tsconfig.json 'src/**/*.ts'",
     "lint:ts:fix": "npm run lint:ts -- --fix",
     "publish-travis": "node_modules/patternfly-eng-publish/script/publish-ghpages.sh -t dist-demo",
     "reinstall": "npm run clean && npm install",

--- a/src/app/action/example/action-example.component.ts
+++ b/src/app/action/example/action-example.component.ts
@@ -27,6 +27,8 @@ export class ActionExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/card/basic-card/example/card-example.component.ts
+++ b/src/app/card/basic-card/example/card-example.component.ts
@@ -26,6 +26,8 @@ export class CardExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/chart/donut-chart/basic-donut-chart/example/donut-chart-example.component.ts
+++ b/src/app/chart/donut-chart/basic-donut-chart/example/donut-chart-example.component.ts
@@ -26,6 +26,8 @@ export class DonutChartExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/copy/block-copy/example/block-copy-example.component.ts
+++ b/src/app/copy/block-copy/example/block-copy-example.component.ts
@@ -16,6 +16,8 @@ export class BlockCopyExampleComponent {
   constructor() {}
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/copy/copy-service/example/copy-service-example.component.ts
+++ b/src/app/copy/copy-service/example/copy-service-example.component.ts
@@ -16,6 +16,8 @@ export class CopyServiceExampleComponent {
   constructor() {}
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/copy/inline-copy/example/inline-copy-example.component.ts
+++ b/src/app/copy/inline-copy/example/inline-copy-example.component.ts
@@ -16,6 +16,8 @@ export class InlineCopyExampleComponent {
   constructor() {}
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/filter/example/filter-example.component.ts
+++ b/src/app/filter/example/filter-example.component.ts
@@ -26,6 +26,8 @@ export class FilterExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/list/basic-list/example/list-example.component.ts
+++ b/src/app/list/basic-list/example/list-example.component.ts
@@ -26,6 +26,8 @@ export class ListExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/list/tree-list/example/tree-list-example.component.ts
+++ b/src/app/list/tree-list/example/tree-list-example.component.ts
@@ -26,6 +26,8 @@ export class TreeListExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/notification/notification-service/example/notification-service-example.component.ts
+++ b/src/app/notification/notification-service/example/notification-service-example.component.ts
@@ -25,6 +25,8 @@ export class NotificationServiceExampleComponent implements OnInit {
 
   // Actions
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/pagination/example/pagination-example.component.ts
+++ b/src/app/pagination/example/pagination-example.component.ts
@@ -23,6 +23,8 @@ export class PaginationExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/table/basic-table/example/table-example.component.ts
+++ b/src/app/table/basic-table/example/table-example.component.ts
@@ -26,6 +26,8 @@ export class TableExampleComponent implements OnInit {
   // Actions
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/app/wizard/example/wizard-example.component.ts
+++ b/src/app/wizard/example/wizard-example.component.ts
@@ -42,6 +42,8 @@ export class WizardExampleComponent implements OnInit {
   }
 
   tabSelected($event: TabDirective): void {
-    this.activeTab = $event.heading;
+    if ($event instanceof TabDirective) {
+      this.activeTab = $event.heading;
+    }
   }
 }

--- a/src/demo/components/includeContent.component.ts
+++ b/src/demo/components/includeContent.component.ts
@@ -1,7 +1,7 @@
 import {
-  Component, Input, OnInit, ViewChild, ViewContainerRef
+  Component, Input, OnInit
 } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { Http } from '@angular/http';
 
 @Component({
   selector: 'include-content',

--- a/src/demo/components/includeMarkdown.component.ts
+++ b/src/demo/components/includeMarkdown.component.ts
@@ -1,10 +1,9 @@
 import {
   Component,
   Input,
-  OnInit,
-  ViewChild
+  OnInit
 } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { Http } from '@angular/http';
 
 const hljs = require('highlight.js');
 const md = require('markdown-it')({


### PR DESCRIPTION
This PR adds an instanceof check for example components, to ensure events triggered from within a tabset are of the correct type before attempting to access heading property of the TabDirective event object.

This seems to be a bug in ngx-bootstrap as they use the `(select)` event binding which collides with the DOM event `select`.

More info here: https://github.com/angular/angular/issues/23603

ensure (select) event is instanceof TabDirective before setting heading
remove unused imports
add flag for project in tslint target