### PR TITLE
Replaced NotificationModule by ToastNotificationModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ This example demonstrates using the Angular-cli to get started with PatternFly-n
 - open `src/app/app.module.ts` and add
 
 ```typescript
-import { NotificationModule } from 'patternfly-ng/notification';
+import { ToastNotificationModule } from 'patternfly-ng/notification';
 // Or
-import { NotificationModule } from 'patternfly-ng';
+import { ToastNotificationModule } from 'patternfly-ng';
 ...
 
 @NgModule({
    ...
-   imports: [NotificationModule, ... ],
+   imports: [ToastNotificationModule, ... ],
     ... 
 })
 ```


### PR DESCRIPTION
If I follow the instructions in the README, I get an error 
```
"export 'NotificationModule' was not found in 'patternfly-ng'
```
since NotificationModule is not found. ToastNotificationModule is found, and fits the component added to the HTML template, i.e. `<pfng-toast-notification />` .