### PR TITLE
vertical-nav: add IDs to primary, secondary, and tertiary links

### DIFF
--- a/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.html
+++ b/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.html
@@ -1,6 +1,6 @@
 <div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" style="background-color: white;"
      *ngIf="showExample">
-  <pfng-vertical-navigation
+  <pfng-vertical-navigation id="myNav"
       [brandAlt]="'PatternFly Ng'"
       [contentContainer]="contentContainer"
       [items]="navigationItems"

--- a/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.ts
+++ b/src/app/navigation/vertical-navigation/example/vertical-navigation-example.component.ts
@@ -202,6 +202,7 @@ export class VerticalNavigationExampleComponent implements OnInit {
       {
         title: 'Amet',
         iconStyleClass: 'fa fa-paper-plane',
+        id: 'myAmetId',
         children: [
           {
             title: 'Detracto',

--- a/src/app/navigation/vertical-navigation/vertical-navigation-item.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation-item.ts
@@ -15,6 +15,11 @@ export class VerticalNavigationItem extends NavigationItemBase {
   activeOnLoad?: boolean;
 
   /**
+   * Unique Id for the navigation item
+   */
+  id?: string;
+
+  /**
    * Track the active state of the navigation item
    */
   trackActiveState?: boolean;
@@ -35,7 +40,7 @@ export class VerticalNavigationItem extends NavigationItemBase {
   tertiaryCollapsed?: boolean;
 
   /**
-   * Indicates if this is a mobile item
+   * Indicates if this is a mobile item -- for component use only
    */
   mobileItem?: boolean;
 

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.html
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.html
@@ -43,7 +43,7 @@
                        'mobile-nav-item-pf': item.mobileItem && showMobileSecondary,
                        'mobile-secondary-item-pf': item.mobileItem && showMobileTertiary}"
             (mouseenter)="handlePrimaryHover(item)" (mouseleave)="handlePrimaryBlur(item)">
-          <a [id]="getId('primary-nav-item', i)" (click)="handlePrimaryClick(item)">
+          <a [id]="getNavItemId('primary-nav-item', i, item)" (click)="handlePrimaryClick(item)">
             <span class="{{item.iconStyleClass}}" *ngIf="item.iconStyleClass" [ngClass]="{hidden: !showIcons}"
                   tooltip="{{item.title}}"
                   container="body"
@@ -74,7 +74,7 @@
                              'is-hover': secondaryItem.trackHoverState,
                              'mobile-nav-item-pf': secondaryItem.mobileItem}"
                   (mouseenter)="handleSecondaryHover(secondaryItem)" (mouseleave)="handleSecondaryBlur(secondaryItem)">
-                <a [id]="getId('secondary-nav-item', i)"
+                <a [id]="getNavItemId('secondary-nav-item', i, secondaryItem)"
                    (click)="handleSecondaryClick(item, secondaryItem)">
                   <span class="list-group-item-value">{{secondaryItem.title}}</span>
                   <div *ngIf="showBadges && secondaryItem.badges" class="badge-container-pf">
@@ -94,7 +94,7 @@
                   </div>
                   <ul class="list-group">
                     <li *ngFor="let tertiaryItem of secondaryItem.children" class="list-group-item" [ngClass]="{'active': tertiaryItem.trackActiveState}">
-                      <a [id]="getId('tertiary-nav-item', i)"
+                      <a [id]="getNavItemId('tertiary-nav-item', i, tertiaryItem)"
                          (click)="handleTertiaryClick(item, secondaryItem, tertiaryItem)">
                         <span class="list-group-item-value">{{tertiaryItem.title}}</span>
                         <div *ngIf="showBadges && tertiaryItem.badges" class="badge-container-pf">

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.html
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.html
@@ -36,14 +36,14 @@
                     'force-hide-secondary-nav-pf': forceHidden,
                     'show-mobile-nav': showMobileNav}">
       <ul class="list-group">
-        <li *ngFor="let item of items" class="list-group-item"
+        <li *ngFor="let item of items; let i = index;" class="list-group-item"
             [ngClass]="{'secondary-nav-item-pf': item.children && item.children.length > 0,
                        'active': item.trackActiveState,
                        'is-hover': item.trackHoverState,
                        'mobile-nav-item-pf': item.mobileItem && showMobileSecondary,
                        'mobile-secondary-item-pf': item.mobileItem && showMobileTertiary}"
             (mouseenter)="handlePrimaryHover(item)" (mouseleave)="handlePrimaryBlur(item)">
-          <a (click)="handlePrimaryClick(item)">
+          <a [id]="getId('primary-nav-item', i)" (click)="handlePrimaryClick(item)">
             <span class="{{item.iconStyleClass}}" *ngIf="item.iconStyleClass" [ngClass]="{hidden: !showIcons}"
                   tooltip="{{item.title}}"
                   container="body"
@@ -74,7 +74,8 @@
                              'is-hover': secondaryItem.trackHoverState,
                              'mobile-nav-item-pf': secondaryItem.mobileItem}"
                   (mouseenter)="handleSecondaryHover(secondaryItem)" (mouseleave)="handleSecondaryBlur(secondaryItem)">
-                <a (click)="handleSecondaryClick(item, secondaryItem)">
+                <a [id]="getId('secondary-nav-item', i)"
+                   (click)="handleSecondaryClick(item, secondaryItem)">
                   <span class="list-group-item-value">{{secondaryItem.title}}</span>
                   <div *ngIf="showBadges && secondaryItem.badges" class="badge-container-pf">
                     <div class="badge {{badge.badgeClass}}" *ngFor="let badge of secondaryItem.badges"
@@ -93,7 +94,8 @@
                   </div>
                   <ul class="list-group">
                     <li *ngFor="let tertiaryItem of secondaryItem.children" class="list-group-item" [ngClass]="{'active': tertiaryItem.trackActiveState}">
-                      <a (click)="handleTertiaryClick(item, secondaryItem, tertiaryItem)">
+                      <a [id]="getId('tertiary-nav-item', i)"
+                         (click)="handleTertiaryClick(item, secondaryItem, tertiaryItem)">
                         <span class="list-group-item-value">{{tertiaryItem.title}}</span>
                         <div *ngIf="showBadges && tertiaryItem.badges" class="badge-container-pf">
                           <div class="badge {{badge.badgeClass}}" *ngFor="let badge of tertiaryItem.badges"

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
@@ -206,6 +206,22 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     return result + '-' + suffix + index;
   }
 
+  /**
+   * Return an ID for the given element prefix and index. This ID is overridden by providing an ID via
+   * VerticalNavigationItem.
+   *
+   * @param {string} suffix The element suffix
+   * @param {number} index The current item index
+   * @param {VerticalNavigationItem} The vertical nav item ID to use, if provided
+   * @returns {string}
+   */
+  protected getNavItemId(suffix: string, index: number, item: VerticalNavigationItem): string {
+    if (item.id !== undefined && item.id.length > 0) {
+      return item.id;
+    }
+    return this.getId(suffix, index);
+  }
+
   // Accessors
 
   /**

--- a/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
+++ b/src/app/navigation/vertical-navigation/vertical-navigation.component.ts
@@ -14,6 +14,8 @@ import { NavigationEnd, Router } from '@angular/router';
 import { VerticalNavigationItem } from './vertical-navigation-item';
 import { WindowReference } from '../../utilities/window.reference';
 
+import { uniqueId } from 'lodash';
+
 /**
  * Vertical Navigation component
  *
@@ -134,6 +136,7 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
   private explicitCollapse: boolean = false;
   private hoverDelay: number = 500;
   private hideDelay: number = this.hoverDelay + 200;
+  private id: string = uniqueId('pfng-vertical-navigation');
   private windowListener: any;
 
   /**
@@ -184,6 +187,23 @@ export class VerticalNavigationComponent implements OnInit, OnDestroy {
     if (this.windowListener !== undefined) {
       this.windowRef.nativeWindow.removeEventListener('resize', this.windowListener);
     }
+  }
+
+  /**
+   * Return an ID for the given element prefix and index (e.g., 'pfng-vertical-navigation1-item0')
+   *
+   * Note: The ID prefix can be overridden by providing an id for the pfng-list tag.
+   *
+   * @param {string} suffix The element suffix (e.g., 'item')
+   * @param {number} index The current item index
+   * @returns {string}
+   */
+  protected getId(suffix: string, index: number): string {
+    let result = this.id;
+    if (this.elementRef.nativeElement.id !== undefined && this.elementRef.nativeElement.id.length > 0) {
+      result = this.elementRef.nativeElement.id;
+    }
+    return result + '-' + suffix + index;
   }
 
   // Accessors


### PR DESCRIPTION
Following the patternfly-ng convention for adding IDs with components like list, copy, etc. 

This change outputs a unique link ID based on the ID given to the component. Since the vertical nav is a list of items, the default primary, secondary, and tertiary links also include an index.

```
<a id="pfng-vertical-navigation1-primary-nav-item0">
<a id="pfng-vertical-navigation1-secondary-nav-item0">
<a id="pfng-vertical-navigation1-tertiary-nav-item0">
```

Note that developers have the option to override the default ID (e.g., `pfng-vertical-navigation`) we use as a prefix. For example, if you give the component "myNav" as an ID, those link IDs would look more like this.

```
<a id="myNav-primary-nav-item0">
<a id="myNav-secondary-nav-item0">
<a id="myNav-tertiary-nav-item0">
```

The generated ID can be overridden using VerticalNavigationItem.id