### PR TITLE
Removed nsp check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
   - npm run build
   - npm run build:demo
   - npm run test
-  - node node_modules/.bin/nsp check --output summary
   - sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_verify.sh -x || travis_terminate 1
 
 after_success:


### PR DESCRIPTION
Removed nsp check due to Node Security Platform service being depreciated

Fixes https://github.com/patternfly/patternfly-ng/issues/453