### PR TITLE
fix(peer-dependencies): adjust peer dependencies for Angular 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Welcome to PatternFly-Ng.  This is a library of common Angular components for us
 - API Docs: http://www.patternfly.org/patternfly-ng/
 - Build Status: https://travis-ci.org/patternfly/patternfly-ng.svg?branch=master
 
-
 ### Using PatternFly-ng In Your Application
 
 This example demonstrates using the Angular-cli to get started with PatternFly-ng
@@ -54,7 +53,6 @@ import { ToastNotificationModule } from 'patternfly-ng';
 
 ```json
       "styles": [
-
         "./node_modules/patternfly/dist/css/patternfly.min.css",
         "./node_modules/patternfly/dist/css/patternfly-additions.min.css",
         "./node_modules/patternfly-ng/dist/css/patternfly-ng.min.css",
@@ -70,6 +68,13 @@ import { ToastNotificationModule } from 'patternfly-ng';
   [showClose]="'true'"
   [type]="'success'">
 </pfng-toast-notification>
+```
+
+5. For Angular 8, open `angular.json` and insert the following into the options array
+
+```
+"options": {
+  "preserveSymlinks": true,
 ```
 
 ### Optional Dependencies

--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "npm": ">=5.6.0"
   },
   "peerDependencies": {
-    "@angular/common": "<7.0.0",
-    "@angular/compiler": "<7.0.0",
-    "@angular/core": "<7.0.0",
-    "@angular/forms": "<7.0.0",
+    "@angular/common": "<8.0.0",
+    "@angular/compiler": "<8.0.0",
+    "@angular/core": "<8.0.0",
+    "@angular/forms": "<8.0.0",
     "typescript": "^2.9.2",
     "rxjs": "^6.2.2"
   },
@@ -108,7 +108,7 @@
     "@swimlane/ngx-datatable": "^13.0.0",
     "c3": "^0.4.15",
     "ng2-dragula": "^1.5.0",
-    "ngx-bootstrap": "^3.0.0"
+    "ngx-bootstrap": "^3.0.0 || <3.3.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "0.7.1",


### PR DESCRIPTION
This PR adjusts the peer dependencies for Angular 8. 

In addition, I've modified the ngx-bootstrap dependency, as PatternFly-ng is not compatible with the dropdown of ngx-bootstrap v3.3.0. Tested v3.0.0-v3.2.0 and they worked fine.

![Screen Shot 2019-06-11 at 3 01 19 PM](https://user-images.githubusercontent.com/17481322/59301197-11cdea00-8c5f-11e9-8bff-84ae6c30f894.png)

For Angular 8, the following must be added to the options of agular.json

```
"options": {
  "preserveSymlinks": true,
```

See: https://stackoverflow.com/questions/53833985/no-provider-for-viewcontainerref-while-using-ng-packagr-component